### PR TITLE
Add sentinel in tf slides

### DIFF
--- a/instruqt-tracks/sentinel-for-terraform/track.yml
+++ b/instruqt-tracks/sentinel-for-terraform/track.yml
@@ -10,7 +10,7 @@ description: |-
 
   In this track, you will write and test policies that restrict resources, data sources, and modules provisioned by Terraform in AWS, Azure, and GCP.
 
-  This track is intended for use with these [slides](https://drive.google.com/open?id=1iFff7wYhiRLQyWiRXDSN6HJ5CGVGy5xI).
+  This track is intended for use with these PowerPoint [slides](https://github.com/hashicorp/field-workshops-terraform/blob/master/docs/slides/multi-cloud/sentinel-for-terraform/Sentinel-in-Terraform.pptx) which you should download.
 
   We recommend starting this track when you can set aside at least 2 hours of uninterrupted time. (The total allocation of 4 hours is for use of the track in a workshop setting in which slides are alternated with the track challenges.) If you find yourself running out of time or are interrupted, we recommend saving all your completed policies outside the track so that you can quickly restore them if forced to begin the track again.
 icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/terraform.png
@@ -520,4 +520,4 @@ challenges:
     hostname: sentinel
   difficulty: basic
   timelimit: 1800
-checksum: "1100184409611799231"
+checksum: "4887536103080621509"


### PR DESCRIPTION
While I ultimately want to migrate these PowerPoint slides to Remark, I don't think I will have time to do that for some time, so I am adding them into the repository.  I think having them here is better than having them in Google Drive which is where customers currently must look (if they have access).

I have also updated the link to the slides in the track.