### PR TITLE
add setup-sentinel script

### DIFF
--- a/instruqt-tracks/sentinel-for-terraform/sentinel-cli/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform/sentinel-cli/setup-sentinel
@@ -1,0 +1,3 @@
+#!/bin/sh -l
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform/track.yml
+++ b/instruqt-tracks/sentinel-for-terraform/track.yml
@@ -520,4 +520,4 @@ challenges:
     hostname: sentinel
   difficulty: basic
   timelimit: 1800
-checksum: "4887536103080621509"
+checksum: "10546822058937044550"


### PR DESCRIPTION
I added a no-op setup-sentinel script to the first challenge of the Sentinel for Terraform track in the hopes that having it might avoid some failures that are sporadically occurring in the solve script of that challenge in CircleCI nightly tests.  At one point, Instruqt suggested adding a no-op setup script when I was getting errors while testing a track.  They said that the error indicated that the check or solve scripts had run before the VM or container was really ready.