### PR TITLE
Protect ORG variable, add escape hatches.

### DIFF
--- a/instruqt-tracks/terraform-build-aws/aws-credentials/check-workstation
+++ b/instruqt-tracks/terraform-build-aws/aws-credentials/check-workstation
@@ -1,2 +1,10 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 grep -q "AWS_SECRET_ACCESS_KEY" /root/.bash_history || fail-message "You haven't checked your credentials yet. We believe in you!"

--- a/instruqt-tracks/terraform-build-aws/complete-the-build/check-workstation
+++ b/instruqt-tracks/terraform-build-aws/complete-the-build/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 source /root/.bashrc
 source /etc/profile.d/instruqt-env.sh
 cd /root/hashicat-aws

--- a/instruqt-tracks/terraform-build-aws/complete-the-build/check-workstation
+++ b/instruqt-tracks/terraform-build-aws/complete-the-build/check-workstation
@@ -13,10 +13,4 @@ cd /root/hashicat-aws
 
 # Fetch the URL and grep the HTTP code for "200 OK"
 # Add retries in case the website isn't up and running yet.
-curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 60 -I $(cat terraform.tfstate | jq -r .outputs.catapp_url.value) | grep "200 OK"
-EXITCODE=$?
-
-if [ $EXITCODE -ne 0 ]; then
-  fail-message "We were unable to load your web app. Try provisioning it again."
-  exit 1
-fi
+curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 60 -I $(cat terraform.tfstate | jq -r .outputs.catapp_url.value) | grep "200 OK" || fail-message "We were unable to load your web app. Try provisioning it again."

--- a/instruqt-tracks/terraform-build-aws/hello-terraform/check-workstation
+++ b/instruqt-tracks/terraform-build-aws/hello-terraform/check-workstation
@@ -1,3 +1,11 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 grep -q "terraform version" /root/.bash_history || fail-message "You haven't run terraform version yet. You can do it!"
 grep -q "terraform help" /root/.bash_history || fail-message "You haven't run terraform help yet. We believe in you!"

--- a/instruqt-tracks/terraform-build-aws/setup-our-environment/check-workstation
+++ b/instruqt-tracks/terraform-build-aws/setup-our-environment/check-workstation
@@ -1,2 +1,10 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 # No check script required here.

--- a/instruqt-tracks/terraform-build-aws/terraform-destroy/check-workstation
+++ b/instruqt-tracks/terraform-build-aws/terraform-destroy/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 cd /root/hashicat-aws
 RESOURCES=$(cat terraform.tfstate | jq '.resources | .[]')
 

--- a/instruqt-tracks/terraform-build-aws/terraform-init-provider/check-workstation
+++ b/instruqt-tracks/terraform-build-aws/terraform-init-provider/check-workstation
@@ -1,2 +1,10 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 [ -d /root/hashicat-aws/.terraform ] || fail-message "Oops, it doesn't look like you've run terraform init yet."

--- a/instruqt-tracks/terraform-build-aws/terraform-validate/check-workstation
+++ b/instruqt-tracks/terraform-build-aws/terraform-validate/check-workstation
@@ -1,3 +1,11 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 cd /root/hashicat-aws
 /usr/local/bin/terraform validate || fail-message "Oops, it looks like there is still an error in your Terraform code."

--- a/instruqt-tracks/terraform-build-aws/terraform-variables/check-workstation
+++ b/instruqt-tracks/terraform-build-aws/terraform-variables/check-workstation
@@ -7,9 +7,4 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep yourname /root/hashicat-aws/terraform.tfvars
-EXITCODE=$?
-if [ $EXITCODE -ne 1 ]; then
-  fail-message "Oops, it looks like you haven't updated your prefix variable yet."
-  exit 1
-fi
+grep yourname /root/hashicat-aws/terraform.tfvars || fail-message "Oops, it looks like you haven't updated your prefix variable yet."

--- a/instruqt-tracks/terraform-build-aws/terraform-variables/check-workstation
+++ b/instruqt-tracks/terraform-build-aws/terraform-variables/check-workstation
@@ -6,4 +6,9 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q yourname /root/hashicat-aws/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+grep yourname /root/hashicat-aws/terraform.tfvars
+EXITCODE=$?
+if [ $EXITCODE -ne 1 ]; then
+  fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+  exit 1
+fi

--- a/instruqt-tracks/terraform-build-aws/terraform-variables/check-workstation
+++ b/instruqt-tracks/terraform-build-aws/terraform-variables/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 grep yourname /root/hashicat-aws/terraform.tfvars
 EXITCODE=$?
 if [ $EXITCODE -ne 1 ]; then

--- a/instruqt-tracks/terraform-build-aws/terraform-variables/check-workstation
+++ b/instruqt-tracks/terraform-build-aws/terraform-variables/check-workstation
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 # Create /tmp/skip-check to disable this check
 if [ -f /tmp/skip-check ]; then
@@ -7,4 +6,4 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep yourname /root/hashicat-aws/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+grep -q yourname /root/hashicat-aws/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."

--- a/instruqt-tracks/terraform-build-aws/terraform-variables/check-workstation
+++ b/instruqt-tracks/terraform-build-aws/terraform-variables/check-workstation
@@ -7,4 +7,4 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep yourname /root/hashicat-aws/terraform.tfvars || fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+grep yourname /root/hashicat-aws/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."

--- a/instruqt-tracks/terraform-build-aws/track.yml
+++ b/instruqt-tracks/terraform-build-aws/track.yml
@@ -1040,4 +1040,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 600
-checksum: "14845610090142879183"
+checksum: "9675090065503091380"

--- a/instruqt-tracks/terraform-build-aws/track.yml
+++ b/instruqt-tracks/terraform-build-aws/track.yml
@@ -1040,4 +1040,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 600
-checksum: "2377024788589705703"
+checksum: "2044235774701790626"

--- a/instruqt-tracks/terraform-build-aws/track.yml
+++ b/instruqt-tracks/terraform-build-aws/track.yml
@@ -1040,4 +1040,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 600
-checksum: "18033232145777034280"
+checksum: "2377024788589705703"

--- a/instruqt-tracks/terraform-build-aws/track.yml
+++ b/instruqt-tracks/terraform-build-aws/track.yml
@@ -1040,4 +1040,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 600
-checksum: "9675090065503091380"
+checksum: "18033232145777034280"

--- a/instruqt-tracks/terraform-build-aws/use-a-provisioner/check-workstation
+++ b/instruqt-tracks/terraform-build-aws/use-a-provisioner/check-workstation
@@ -1,2 +1,10 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 grep cowsay main.tf || fail-message "We couldn't find the cowsay install commands in your provisioner inline list."

--- a/instruqt-tracks/terraform-build-azure/add-a-tag/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/add-a-tag/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 # Checks the state file to make sure the student has added a tag.
 cd /root/hashicat-azure
 

--- a/instruqt-tracks/terraform-build-azure/add-an-output/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/add-an-output/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 cd /root/hashicat-azure
 OUTPUT=$(cat terraform.tfstate | jq -r .outputs.catapp_ip.value)
 

--- a/instruqt-tracks/terraform-build-azure/add-virtual-network/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/add-virtual-network/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 # Checks the state file to make sure the student has added a tag.
 cd /root/hashicat-azure
 

--- a/instruqt-tracks/terraform-build-azure/change-location/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/change-location/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 cd /root/hashicat-azure
 source /root/.bashrc
 source /etc/profile.d/instruqt-env.sh

--- a/instruqt-tracks/terraform-build-azure/complete-the-build/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/complete-the-build/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 cd /root/hashicat-azure
 
 curl -I $(cat terraform.tfstate | jq -r .outputs.catapp_url.value) | grep "200 OK"

--- a/instruqt-tracks/terraform-build-azure/complete-the-build/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/complete-the-build/check-workstation
@@ -10,9 +10,4 @@ fi
 cd /root/hashicat-azure
 
 curl -I $(cat terraform.tfstate | jq -r .outputs.catapp_url.value) | grep "200 OK"
-EXITCODE=$?
-
-if [ $EXITCODE -ne 0 ]; then
-  fail-message "We were unable to load your web app. Try provisioning it again."
-  exit 1
-fi
+EXITCODE=$? || fail-message "We were unable to load your web app. Try provisioning it again."

--- a/instruqt-tracks/terraform-build-azure/complete-the-build/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/complete-the-build/check-workstation
@@ -9,5 +9,4 @@ fi
 
 cd /root/hashicat-azure
 
-curl -I $(cat terraform.tfstate | jq -r .outputs.catapp_url.value) | grep "200 OK"
-EXITCODE=$? || fail-message "We were unable to load your web app. Try provisioning it again."
+curl -I $(cat terraform.tfstate | jq -r .outputs.catapp_url.value) | grep "200 OK" || fail-message "We were unable to load your web app. Try provisioning it again."

--- a/instruqt-tracks/terraform-build-azure/hello-terraform/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/hello-terraform/check-workstation
@@ -1,3 +1,11 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 grep -q "terraform version" /root/.bash_history || fail-message "You haven't run terraform version yet. You can do it!"
 grep -q "terraform help" /root/.bash_history || fail-message "You haven't run terraform help yet. We believe in you!"

--- a/instruqt-tracks/terraform-build-azure/setup-our-environment/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/setup-our-environment/check-workstation
@@ -1,2 +1,10 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 # No check script required here.

--- a/instruqt-tracks/terraform-build-azure/terraform-destroy/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/terraform-destroy/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 cd /root/hashicat-azure
 RESOURCES=$(cat terraform.tfstate | jq '.resources | .[]')
 

--- a/instruqt-tracks/terraform-build-azure/tf-add-a-variable/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-add-a-variable/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 grep yourname /root/hashicat-azure/terraform.tfvars
 EXITCODE=$?
 if [ $EXITCODE -ne 1 ]; then

--- a/instruqt-tracks/terraform-build-azure/tf-add-a-variable/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-add-a-variable/check-workstation
@@ -7,9 +7,4 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep yourname /root/hashicat-azure/terraform.tfvars
-EXITCODE=$?
-if [ $EXITCODE -ne 1 ]; then
-  fail-message "Oops, it looks like you haven't updated your prefix variable yet."
-  exit 1
-fi
+grep yourname /root/hashicat-azure/terraform.tfvars || fail-message "Oops, it looks like you haven't updated your prefix variable yet."

--- a/instruqt-tracks/terraform-build-azure/tf-add-a-variable/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-add-a-variable/check-workstation
@@ -7,4 +7,4 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep yourname /root/hashicat-azure/terraform.tfvars || fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+grep yourname /root/hashicat-azure/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."

--- a/instruqt-tracks/terraform-build-azure/tf-add-a-variable/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-add-a-variable/check-workstation
@@ -6,4 +6,9 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q yourname /root/hashicat-azure/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+grep yourname /root/hashicat-azure/terraform.tfvars
+EXITCODE=$?
+if [ $EXITCODE -ne 1 ]; then
+  fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+  exit 1
+fi

--- a/instruqt-tracks/terraform-build-azure/tf-add-a-variable/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-add-a-variable/check-workstation
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 # Create /tmp/skip-check to disable this check
 if [ -f /tmp/skip-check ]; then
@@ -7,4 +6,4 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep yourname /root/hashicat-azure/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+grep -q yourname /root/hashicat-azure/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."

--- a/instruqt-tracks/terraform-build-azure/tf-graph/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-graph/check-workstation
@@ -8,9 +8,4 @@ if [ -f /tmp/skip-check ]; then
 fi
 
 # Fix this after getting the solve script working.
-# curl -I http://localhost:5000 | grep -q "HTTP/1.0 200 OK"
-# EXITCODE=$?
-# if [ $EXITCODE -ne 0 ]; then
-#   fail-message "Oops, it looks like the Blast Radius tool is not running."
-#   exit 1
-# fi
+# curl -I http://localhost:5000 | grep -q "HTTP/1.0 200 OK" || fail-message "Oops, it looks like the Blast Radius tool is not running."

--- a/instruqt-tracks/terraform-build-azure/tf-graph/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-graph/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 # Fix this after getting the solve script working.
 # curl -I http://localhost:5000 | grep -q "HTTP/1.0 200 OK"
 # EXITCODE=$?

--- a/instruqt-tracks/terraform-build-azure/tf-init-provider/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-init-provider/check-workstation
@@ -1,2 +1,10 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 [ -d /root/hashicat-azure/.terraform ] || fail-message "Oops, it doesn't look like you've run terraform init yet."

--- a/instruqt-tracks/terraform-build-azure/tf-plan-and-apply/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-plan-and-apply/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 cd /root/hashicat-azure
 if [ ! -f terraform.tfstate ]; then
   fail-message "Oops, it looks like you haven't run terraform apply yet."

--- a/instruqt-tracks/terraform-build-azure/tf-validate/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-validate/check-workstation
@@ -1,3 +1,11 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 cd /root/hashicat-azure
 /usr/local/bin/terraform validate || fail-message "Oops, it looks like there is still an error in your Terraform code."

--- a/instruqt-tracks/terraform-build-azure/tf-variables/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-variables/check-workstation
@@ -7,9 +7,4 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep yourname /root/hashicat-azure/terraform.tfvars 
-EXITCODE=$?
-if [ $EXITCODE -ne 1 ]; then
-  fail-message "Oops, it looks like you haven't updated your prefix variable yet."
-  exit 1
-fi
+grep yourname /root/hashicat-azure/terraform.tfvars || fail-message "Oops, it looks like you haven't updated your prefix variable yet."

--- a/instruqt-tracks/terraform-build-azure/tf-variables/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-variables/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 grep yourname /root/hashicat-azure/terraform.tfvars 
 EXITCODE=$?
 if [ $EXITCODE -ne 1 ]; then

--- a/instruqt-tracks/terraform-build-azure/tf-variables/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-variables/check-workstation
@@ -7,4 +7,4 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep yourname /root/hashicat-azure/terraform.tfvars || fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+grep yourname /root/hashicat-azure/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."

--- a/instruqt-tracks/terraform-build-azure/tf-variables/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-variables/check-workstation
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 # Create /tmp/skip-check to disable this check
 if [ -f /tmp/skip-check ]; then

--- a/instruqt-tracks/terraform-build-azure/tf-variables/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/tf-variables/check-workstation
@@ -7,4 +7,9 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep yourname /root/hashicat-azure/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+grep yourname /root/hashicat-azure/terraform.tfvars
+EXITCODE=$?
+if [ $EXITCODE -ne 1 ]; then
+  fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+  exit 1
+fi

--- a/instruqt-tracks/terraform-build-azure/track.yml
+++ b/instruqt-tracks/terraform-build-azure/track.yml
@@ -1035,4 +1035,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 600
-checksum: "11269588790140943785"
+checksum: "15672277407859373706"

--- a/instruqt-tracks/terraform-build-azure/track.yml
+++ b/instruqt-tracks/terraform-build-azure/track.yml
@@ -1035,4 +1035,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 600
-checksum: "943277156112677103"
+checksum: "8954432000155174265"

--- a/instruqt-tracks/terraform-build-azure/track.yml
+++ b/instruqt-tracks/terraform-build-azure/track.yml
@@ -1035,4 +1035,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 600
-checksum: "14411967097858531304"
+checksum: "2021832279682772473"

--- a/instruqt-tracks/terraform-build-azure/track.yml
+++ b/instruqt-tracks/terraform-build-azure/track.yml
@@ -1035,4 +1035,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 600
-checksum: "15672277407859373706"
+checksum: "943277156112677103"

--- a/instruqt-tracks/terraform-build-azure/track.yml
+++ b/instruqt-tracks/terraform-build-azure/track.yml
@@ -1035,4 +1035,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 600
-checksum: "15467321871117095440"
+checksum: "18087776948795906840"

--- a/instruqt-tracks/terraform-build-azure/track.yml
+++ b/instruqt-tracks/terraform-build-azure/track.yml
@@ -1035,4 +1035,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 600
-checksum: "18087776948795906840"
+checksum: "14411967097858531304"

--- a/instruqt-tracks/terraform-build-azure/track.yml
+++ b/instruqt-tracks/terraform-build-azure/track.yml
@@ -1035,4 +1035,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 600
-checksum: "2021832279682772473"
+checksum: "11269588790140943785"

--- a/instruqt-tracks/terraform-build-azure/use-a-provisioner/check-workstation
+++ b/instruqt-tracks/terraform-build-azure/use-a-provisioner/check-workstation
@@ -1,2 +1,10 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 grep cowsay main.tf || fail-message "We couldn't find the cowsay install commands in your provisioner inline list."

--- a/instruqt-tracks/terraform-cloud-aws/a-sentinel-stands-guard/check-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/a-sentinel-stands-guard/check-workstation
@@ -1,10 +1,17 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 /bin/set-workdir /root/hashicat-aws
 
 # Get our TFC token and organization from the local config files
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-aws/remote_backend.tf | cut -d '"' -f2)
 
 curl -s --header "Authorization: Bearer $TOKEN"   https://app.terraform.io/api/v2/organizations/$ORG/policy-sets | jq -r '.data | .[] | .attributes.name' | grep tfc-workshops-sentinel || fail-message "Uh oh, it looks like you haven't attached the tfc-workshops-sentinel policy set to your organization. Make sure you have forked the repo and added the policy set to your organization."

--- a/instruqt-tracks/terraform-cloud-aws/api-driven-workflows/check-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/api-driven-workflows/check-workstation
@@ -1,10 +1,17 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 /bin/set-workdir /root/hashicat-aws
 
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-aws/remote_backend.tf | cut -d '"' -f2)
 
 # Does the workspace have a placeholder variable
 curl -s --header "Authorization: Bearer $TOKEN"   --header "Content-Type: application/vnd.api+json" "https://app.terraform.io/api/v2/vars?filter%5Borganization%5D%5Bname%5D=$ORG&filter%5Bworkspace%5D%5Bname%5D=hashicat-aws" | grep -q "placeholder" || fail-message "Oh dear, it looks like you don't have a Terraform variable called 'placeholder' in your workspace. Read the notes if you need a hint on how to create this variable with the API."

--- a/instruqt-tracks/terraform-cloud-aws/oh-no-an-outage/check-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/oh-no-an-outage/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 /bin/set-workdir /root/hashicat-aws
@@ -20,3 +28,6 @@ curl -I -s -L --header "Authorization: Bearer $TOKEN" --header "Content-Type: ap
 
 # Verify the workspace exists in TFC
 curl -I -s -L --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-aws | grep "HTTP/2 200" || fail-message "I couldn't find the hashicat-aws workspace in your organization $ORG. Make sure you created it and that it is configured in your remote_backend.tf file."
+
+# Store the ORG in /root/.bashrc
+grep $ORG /root/.bashrc || echo "export ORG=\"$ORG\"" >> /root/.bashrc

--- a/instruqt-tracks/terraform-cloud-aws/private-module-registry/check-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/private-module-registry/check-workstation
@@ -1,10 +1,17 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 /bin/set-workdir /root/hashicat-aws
 
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-aws/remote_backend.tf | cut -d '"' -f2)
 
 # Fetch the workspace ID
 WORKSPACE_ID=$(curl -s --header "Authorization: Bearer $TOKEN"   --header "Content-Type: application/vnd.api+json"   https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-aws | jq -r .data.id)

--- a/instruqt-tracks/terraform-cloud-aws/protecting-sensitive-variables/check-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/protecting-sensitive-variables/check-workstation
@@ -1,10 +1,17 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 /bin/set-workdir /root/hashicat-aws
 
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-aws/remote_backend.tf | cut -d '"' -f2)
 
 # Test whether remote exec is enabled on the workspace.
 REMOTE_EXEC_ENABLED=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-aws | jq .data.attributes.operations)

--- a/instruqt-tracks/terraform-cloud-aws/setup-our-environment/check-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/setup-our-environment/check-workstation
@@ -1,2 +1,10 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 # This is just a placeholder.

--- a/instruqt-tracks/terraform-cloud-aws/sharing-is-caring/check-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/sharing-is-caring/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 # TODO - DRY this out a bit.
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
@@ -6,7 +14,6 @@ source /root/.bashrc
 
 # Get our TFC token and organization from the local config files
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-aws/remote_backend.tf | cut -d '"' -f2)
 
 # Get our team IDs. In the test environment these teams are pre-created.
 ADMINS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("admins")) | .id')

--- a/instruqt-tracks/terraform-cloud-aws/sharing-is-caring/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/sharing-is-caring/solve-workstation
@@ -5,7 +5,6 @@ source /root/.bashrc
 
 # Get our TFC token and organization from the local config files
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-aws/remote_backend.tf | cut -d '"' -f2)
 
 # These are the terraform cloud IDs of our fictional users. They are persistent and should not be deleted from TFC.
 LARS_ID="user-V2Qt225RgAUzsWpz"

--- a/instruqt-tracks/terraform-cloud-aws/this-is-the-end/cleanup-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/this-is-the-end/cleanup-workstation
@@ -4,7 +4,6 @@ source /root/.bashrc
 /bin/set-workdir /root/hashicat-aws
 cd /root/hashicat-aws
 
-ORG=$(grep organization /root/hashicat-aws/remote_backend.tf | cut -d '"' -f2)
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
 
 # Delete the workspace

--- a/instruqt-tracks/terraform-cloud-aws/track.yml
+++ b/instruqt-tracks/terraform-cloud-aws/track.yml
@@ -723,4 +723,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1800
-checksum: "16129095508785309899"
+checksum: "10221047930757039464"

--- a/instruqt-tracks/terraform-cloud-aws/versioned-infrastructure/check-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/versioned-infrastructure/check-workstation
@@ -1,11 +1,18 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 /bin/set-workdir /root/hashicat-aws
 
 # Get our TFC token and organization from the local config files
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-aws/remote_backend.tf | cut -d '"' -f2)
 
 VCS_HASHICAT=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-aws | jq -r '.data.attributes | .["vcs-repo"] | .identifier' | cut -f2 -d '/')
 

--- a/instruqt-tracks/terraform-cloud-aws/versioned-infrastructure/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/versioned-infrastructure/solve-workstation
@@ -5,7 +5,6 @@ source /root/.bashrc
 
 # Get our TFC token and organization from the local config files
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-aws/remote_backend.tf | cut -d '"' -f2)
 WORKSPACE_ID=$(curl -s --header "Authorization: Bearer $TOKEN"   --header "Content-Type: application/vnd.api+json"   https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-aws | jq -r .data.id)
 
 # Update the workspace with VCS settings

--- a/instruqt-tracks/terraform-cloud-azure/a-sentinel-stands-guard/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/a-sentinel-stands-guard/check-workstation
@@ -1,10 +1,17 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 /bin/set-workdir /root/hashicat-aws
 
 # Get our TFC token and organization from the local config files
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-azure/remote_backend.tf | cut -d '"' -f2)
 
 curl -s --header "Authorization: Bearer $TOKEN"   https://app.terraform.io/api/v2/organizations/$ORG/policy-sets | jq -r '.data | .[] | .attributes.name' | grep tfc-workshops-sentinel || fail-message "Uh oh, it looks like you haven't attached the tfc-workshops-sentinel policy set to your organization. Make sure you have forked the repo and added the policy set to your organization."

--- a/instruqt-tracks/terraform-cloud-azure/api-driven-workflows/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/api-driven-workflows/check-workstation
@@ -1,10 +1,17 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 /bin/set-workdir /root/hashicat-azure
 
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-azure/remote_backend.tf | cut -d '"' -f2)
 
 # Does the workspace have a placeholder variable
 curl -s --header "Authorization: Bearer $TOKEN"   --header "Content-Type: application/vnd.api+json" "https://app.terraform.io/api/v2/vars?filter%5Borganization%5D%5Bname%5D=$ORG&filter%5Bworkspace%5D%5Bname%5D=hashicat-azure" | grep -q "placeholder" || fail-message "Oh dear, it looks like you don't have a Terraform variable called 'placeholder' in your workspace. Read the notes if you need a hint on how to create this variable with the API."

--- a/instruqt-tracks/terraform-cloud-azure/oh-no-an-outage/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/oh-no-an-outage/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 /bin/set-workdir /root/hashicat-azure
@@ -20,3 +28,6 @@ curl -I -s -L --header "Authorization: Bearer $TOKEN" --header "Content-Type: ap
 
 # Verify the workspace exists in TFC
 curl -I -s -L --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-azure | grep "HTTP/2 200" || fail-message "I couldn't find the hashicat-azure workspace in your organization $ORG. Make sure you created it and that it is configured in your remote_backend.tf file."
+
+# Store the ORG in /root/.bashrc
+grep $ORG /root/.bashrc || echo "export ORG=\"$ORG\"" >> /root/.bashrc

--- a/instruqt-tracks/terraform-cloud-azure/private-module-registry/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/private-module-registry/check-workstation
@@ -1,10 +1,17 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 /bin/set-workdir /root/hashicat-azure
 
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-azure/remote_backend.tf | cut -d '"' -f2)
 
 # Fetch the workspace ID
 WORKSPACE_ID=$(curl -s --header "Authorization: Bearer $TOKEN"   --header "Content-Type: application/vnd.api+json"   https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-azure | jq -r .data.id)

--- a/instruqt-tracks/terraform-cloud-azure/protecting-sensitive-variables/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/protecting-sensitive-variables/check-workstation
@@ -1,10 +1,17 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 /bin/set-workdir /root/hashicat-azure
 
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-azure/remote_backend.tf | cut -d '"' -f2)
 
 # Test whether remote exec is enabled on the workspace.
 REMOTE_EXEC_ENABLED=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-azure | jq .data.attributes.operations)

--- a/instruqt-tracks/terraform-cloud-azure/setup-our-environment/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/setup-our-environment/check-workstation
@@ -1,2 +1,10 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 # This is just a placeholder.

--- a/instruqt-tracks/terraform-cloud-azure/sharing-is-caring/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/sharing-is-caring/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 # TODO - DRY this out a bit.
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
@@ -6,7 +14,6 @@ source /root/.bashrc
 
 # Get our TFC token and organization from the local config files
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-azure/remote_backend.tf | cut -d '"' -f2)
 
 # Get our team IDs. In the test environment these teams are pre-created.
 ADMINS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("admins")) | .id')

--- a/instruqt-tracks/terraform-cloud-azure/sharing-is-caring/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/sharing-is-caring/solve-workstation
@@ -5,7 +5,6 @@ source /root/.bashrc
 
 # Get our TFC token and organization from the local config files
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-azure/remote_backend.tf | cut -d '"' -f2)
 
 # These are the terraform cloud IDs of our fictional users. They are persistent and should not be deleted from TFC.
 LARS_ID="user-V2Qt225RgAUzsWpz"

--- a/instruqt-tracks/terraform-cloud-azure/tf-variables/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/tf-variables/check-workstation
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 grep yourname /root/hashicat-azure/terraform.tfvars
 EXITCODE=$?
 if [ $EXITCODE -ne 1 ]; then

--- a/instruqt-tracks/terraform-cloud-azure/tf-variables/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/tf-variables/check-workstation
@@ -7,9 +7,4 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep yourname /root/hashicat-azure/terraform.tfvars
-EXITCODE=$?
-if [ $EXITCODE -ne 1 ]; then
-  fail-message "Oops, it looks like you haven't updated your prefix variable yet."
-  exit 1
-fi
+grep yourname /root/hashicat-azure/terraform.tfvars || fail-message "Oops, it looks like you haven't updated your prefix variable yet."

--- a/instruqt-tracks/terraform-cloud-azure/tf-variables/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/tf-variables/check-workstation
@@ -7,4 +7,4 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep yourname /root/hashicat-azure/terraform.tfvars || fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+grep yourname /root/hashicat-azure/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."

--- a/instruqt-tracks/terraform-cloud-azure/tf-variables/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/tf-variables/check-workstation
@@ -6,4 +6,9 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q yourname /root/hashicat-azure/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+grep yourname /root/hashicat-azure/terraform.tfvars
+EXITCODE=$?
+if [ $EXITCODE -ne 1 ]; then
+  fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+  exit 1
+fi

--- a/instruqt-tracks/terraform-cloud-azure/tf-variables/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/tf-variables/check-workstation
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 # Create /tmp/skip-check to disable this check
 if [ -f /tmp/skip-check ]; then
@@ -7,4 +6,4 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep yourname /root/hashicat-azure/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."
+grep -q yourname /root/hashicat-azure/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."

--- a/instruqt-tracks/terraform-cloud-azure/this-is-the-end/cleanup-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/this-is-the-end/cleanup-workstation
@@ -4,7 +4,6 @@ source /root/.bashrc
 /bin/set-workdir /root/hashicat-azure
 cd /root/hashicat-azure
 
-ORG=$(grep organization /root/hashicat-azure/remote_backend.tf | cut -d '"' -f2)
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
 
 # Delete the workspace

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -748,4 +748,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1800
-checksum: "2166073371076386186"
+checksum: "17375770800154211247"

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -748,4 +748,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1800
-checksum: "5089010797045753203"
+checksum: "2166073371076386186"

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -748,4 +748,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1800
-checksum: "14110684570300939434"
+checksum: "5089010797045753203"

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -748,4 +748,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1800
-checksum: "17375770800154211247"
+checksum: "18144262138633927547"

--- a/instruqt-tracks/terraform-cloud-azure/versioned-infrastructure/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/versioned-infrastructure/check-workstation
@@ -1,11 +1,18 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 /bin/set-workdir /root/hashicat-azure
 
 # Get our TFC token and organization from the local config files
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-azure/remote_backend.tf | cut -d '"' -f2)
 
 VCS_HASHICAT=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-azure | jq -r '.data.attributes | .["vcs-repo"] | .identifier' | cut -f2 -d '/')
 

--- a/instruqt-tracks/terraform-cloud-azure/versioned-infrastructure/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/versioned-infrastructure/solve-workstation
@@ -5,7 +5,6 @@ source /root/.bashrc
 
 # Get our TFC token and organization from the local config files
 TOKEN=$(grep token /root/.terraformrc | cut -d '"' -f2)
-ORG=$(grep organization /root/hashicat-azure/remote_backend.tf | cut -d '"' -f2)
 WORKSPACE_ID=$(curl -s --header "Authorization: Bearer $TOKEN"   --header "Content-Type: application/vnd.api+json"   https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-azure | jq -r .data.id)
 
 # Update the workspace with VCS settings

--- a/instruqt-tracks/terraform-cloud-bonus-lab/setup-our-environment/check-workstation
+++ b/instruqt-tracks/terraform-cloud-bonus-lab/setup-our-environment/check-workstation
@@ -1,2 +1,10 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 # No check script required here.

--- a/instruqt-tracks/terraform-cloud-bonus-lab/track.yml
+++ b/instruqt-tracks/terraform-cloud-bonus-lab/track.yml
@@ -98,4 +98,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 7200
-checksum: "15743728892928250087"
+checksum: "9193040488150437870"

--- a/instruqt-tracks/terraform-workshop-base/setup-our-environment/check-workstation
+++ b/instruqt-tracks/terraform-workshop-base/setup-our-environment/check-workstation
@@ -1,2 +1,10 @@
 #!/bin/bash
+set -e
+
+# Create /tmp/skip-check to disable this check
+if [ -f /tmp/skip-check ]; then
+    rm /tmp/skip-check
+    exit 0
+fi
+
 # No check script required here.

--- a/instruqt-tracks/terraform-workshop-base/track.yml
+++ b/instruqt-tracks/terraform-workshop-base/track.yml
@@ -88,4 +88,4 @@ challenges:
     port: 8443
   difficulty: basic
   timelimit: 600
-checksum: "14961132010962664061"
+checksum: "10810864884635183064"


### PR DESCRIPTION
This pull request addresses the following issues:

1. Students were deleting the remote_backend.tf file halfway through the workshop. Now we fetch the organization and store it in /root/.bashrc instead
2. Added an 'escape hatch'. Instructors can now create a /tmp/skip-check file to override any check.