### PR TITLE
Add Instruqt text editor to challenges.

### DIFF
--- a/instruqt-tracks/terraform-build-aws/track.yml
+++ b/instruqt-tracks/terraform-build-aws/track.yml
@@ -56,6 +56,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -88,6 +92,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -135,6 +143,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -169,6 +181,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -207,6 +223,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -248,6 +268,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -304,6 +328,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -337,6 +365,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -368,6 +400,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -413,6 +449,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -507,6 +547,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -549,6 +593,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -587,6 +635,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -619,6 +671,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -651,6 +707,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -693,6 +753,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -800,6 +864,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -850,6 +918,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -912,6 +984,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -963,6 +1039,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -1005,6 +1085,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -1035,9 +1119,13 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
   difficulty: basic
   timelimit: 600
-checksum: "13009636139831267340"
+checksum: "6490598711360394414"

--- a/instruqt-tracks/terraform-build-azure/track.yml
+++ b/instruqt-tracks/terraform-build-azure/track.yml
@@ -56,6 +56,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -88,6 +92,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   difficulty: basic
   timelimit: 600
 - slug: hello-terraform
@@ -132,6 +140,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -172,6 +184,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -210,6 +226,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -248,6 +268,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -304,6 +328,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -339,6 +367,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -370,6 +402,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -409,6 +445,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -503,6 +543,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -545,6 +589,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -588,6 +636,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -620,6 +672,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -652,6 +708,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -688,6 +748,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -795,6 +859,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -845,6 +913,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -907,6 +979,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -958,6 +1034,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -1000,6 +1080,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -1030,9 +1114,13 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
   difficulty: basic
   timelimit: 600
-checksum: "8954432000155174265"
+checksum: "18414944407727394957"

--- a/instruqt-tracks/terraform-cloud-aws/track.yml
+++ b/instruqt-tracks/terraform-cloud-aws/track.yml
@@ -423,6 +423,14 @@ challenges:
 
       In addition it allows you to enable features like code reviews, pull requests, and automated testing of your code.
   tabs:
+  - title: Code Editor
+    type: service
+    hostname: workstation
+    port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -432,14 +440,6 @@ challenges:
   - title: Terraform Cloud
     type: external
     url: https://app.terraform.io
-  - title: Code Editor
-    type: service
-    hostname: workstation
-    port: 8443
-  - title: Text Editor
-    type: code
-    hostname: workstation
-    path: /root/hashicat-aws
   difficulty: basic
   timelimit: 1800
 - slug: vcs-collaboration
@@ -763,4 +763,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1800
-checksum: "11283916412402512336"
+checksum: "5797138593494152350"

--- a/instruqt-tracks/terraform-cloud-aws/track.yml
+++ b/instruqt-tracks/terraform-cloud-aws/track.yml
@@ -72,6 +72,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   difficulty: basic
   timelimit: 1800
 - slug: open-a-terminal
@@ -105,6 +109,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -181,6 +189,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -268,6 +280,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -407,10 +423,6 @@ challenges:
 
       In addition it allows you to enable features like code reviews, pull requests, and automated testing of your code.
   tabs:
-  - title: Code Editor
-    type: service
-    hostname: workstation
-    port: 8443
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -420,6 +432,14 @@ challenges:
   - title: Terraform Cloud
     type: external
     url: https://app.terraform.io
+  - title: Code Editor
+    type: service
+    hostname: workstation
+    port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   difficulty: basic
   timelimit: 1800
 - slug: vcs-collaboration
@@ -464,6 +484,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -532,6 +556,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -604,6 +632,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -676,6 +708,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -718,9 +754,13 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-aws
   - title: Terminal
     type: terminal
     hostname: workstation
   difficulty: basic
   timelimit: 1800
-checksum: "3626677872229187752"
+checksum: "11283916412402512336"

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -72,6 +72,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   difficulty: basic
   timelimit: 1800
 - slug: open-a-terminal
@@ -105,6 +109,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -133,6 +141,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   difficulty: basic
   timelimit: 600
 - slug: terraform-cloud-setup
@@ -206,6 +218,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -292,6 +308,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -435,6 +455,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -488,6 +512,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -556,6 +584,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -629,6 +661,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
@@ -707,6 +743,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   difficulty: basic
   timelimit: 1800
 - slug: quiz-4
@@ -743,9 +783,13 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root/hashicat-azure
   - title: Terminal
     type: terminal
     hostname: workstation
   difficulty: basic
   timelimit: 1800
-checksum: "12419350113177536156"
+checksum: "1604999519982641510"

--- a/instruqt-tracks/terraform-cloud-bonus-lab/track.yml
+++ b/instruqt-tracks/terraform-cloud-bonus-lab/track.yml
@@ -93,9 +93,13 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root
   - title: Terminal
     type: terminal
     hostname: workstation
   difficulty: basic
   timelimit: 7200
-checksum: "9193040488150437870"
+checksum: "16011051812239516204"

--- a/instruqt-tracks/terraform-workshop-base/track.yml
+++ b/instruqt-tracks/terraform-workshop-base/track.yml
@@ -57,6 +57,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root
   difficulty: basic
   timelimit: 600
 - slug: open-a-terminal
@@ -86,6 +90,10 @@ challenges:
     type: service
     hostname: workstation
     port: 8443
+  - title: Text Editor
+    type: code
+    hostname: workstation
+    path: /root
   difficulty: basic
   timelimit: 600
-checksum: "10810864884635183064"
+checksum: "3995523609525234314"


### PR DESCRIPTION
Users have reported that VSC sometimes crashes and never comes back, leaving them stuck and without a GUI text editor to finish the track. This adds a second text editor to each challenge that requires one, just in case VSC fails.