### PR TITLE
locked down remarkjs 0.14.0

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/aws/index.html
+++ b/docs/slides/aws/index.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/aws/terraform-cloud/index.html
+++ b/docs/slides/aws/terraform-cloud/index.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/aws/terraform-oss/index.html
+++ b/docs/slides/aws/terraform-oss/index.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/azure/index.html
+++ b/docs/slides/azure/index.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/azure/terraform-cloud/index.html
+++ b/docs/slides/azure/terraform-cloud/index.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/azure/terraform-oss/index.html
+++ b/docs/slides/azure/terraform-oss/index.html
@@ -34,7 +34,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/gcp/index.html
+++ b/docs/slides/gcp/index.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/gcp/terraform-enterprise/index.html
+++ b/docs/slides/gcp/terraform-enterprise/index.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/gcp/terraform-oss/index.html
+++ b/docs/slides/gcp/terraform-oss/index.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/index.html
+++ b/docs/slides/index.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/index.html
+++ b/docs/slides/multi-cloud/index.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/terraform-enterprise/index.html
+++ b/docs/slides/multi-cloud/terraform-enterprise/index.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;

--- a/docs/slides/multi-cloud/terraform-oss/index.html
+++ b/docs/slides/multi-cloud/terraform-oss/index.html
@@ -35,7 +35,7 @@
 </head>
 
 <body>
-    <script src="https://remarkjs.com/downloads/remark-latest.min.js" type="text/javascript"></script>
+    <script src="https://remarkjs.com/downloads/remark-0.14.0.min.js" type="text/javascript"></script>
     <script>
       remark.macros.scale = function (percentage) {
         var url = this;


### PR DESCRIPTION
This locks down remark.js to v0.14.0 since the recent release of 0.15.0 broke all our workshop websites.  Previously, we just used https://remarkjs.com/downloads/remark-latest.min.js.  Now, I have pinned it to https://remarkjs.com/downloads/remark-0.14.0.min.js until 0.15.x is fixed.