### PR TITLE
Push before test.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,11 @@ jobs:
             else
               echo "Instruqt is installed and updated to most recent version."
             fi
-            echo "Running instruqt track test..."
             cd /root/project/instruqt-tracks/terraform-build-aws
-            instruqt track test --skip-fail-check
             echo "Running instruqt track push..."
             instruqt track push --force
+            echo "Running instruqt track test..."
+            instruqt track test --skip-fail-check
   instruqt-test-oss-azure:
     filters:
       branches:
@@ -90,11 +90,11 @@ jobs:
             else
               echo "Instruqt is installed and updated to most recent version."
             fi
-            echo "Running instruqt track test..."
             cd /root/project/instruqt-tracks/terraform-build-azure
-            instruqt track test --skip-fail-check
             echo "Running instruqt track push..."
             instruqt track push --force
+            echo "Running instruqt track test..."
+            instruqt track test --skip-fail-check
   instruqt-test-cloud-aws:
     filters:
       branches:
@@ -122,11 +122,11 @@ jobs:
             else
               echo "Instruqt is installed and updated to most recent version."
             fi
-            echo "Running instruqt track test..."
             cd /root/project/instruqt-tracks/terraform-cloud-aws
-            instruqt track test --skip-fail-check
             echo "Running instruqt track push..."
             instruqt track push --force
+            echo "Running instruqt track test..."
+            instruqt track test --skip-fail-check
   instruqt-test-cloud-azure:
     filters:
       branches:
@@ -154,11 +154,11 @@ jobs:
             else
               echo "Instruqt is installed and updated to most recent version."
             fi
-            echo "Running instruqt track test..."
             cd /root/project/instruqt-tracks/terraform-cloud-azure
-            instruqt track test --skip-fail-check
             echo "Running instruqt track push..."
             instruqt track push --force
+            echo "Running instruqt track test..."
+            instruqt track test --skip-fail-check
   instruqt-test-cloud-gcp:
     filters:
       branches:
@@ -186,11 +186,11 @@ jobs:
             else
               echo "Instruqt is installed and updated to most recent version."
             fi
-            echo "Running instruqt track test..."
             cd /root/project/instruqt-tracks/terraform-cloud-gcp
-            instruqt track test --skip-fail-check
             echo "Running instruqt track push..."
             instruqt track push --force
+            echo "Running instruqt track test..."
+            instruqt track test --skip-fail-check
   instruqt-test-sentinel:
     filters:
       branches:
@@ -218,11 +218,11 @@ jobs:
             else
               echo "Instruqt is installed and updated to most recent version."
             fi
-            echo "Running instruqt track test..."
             cd /root/project/instruqt-tracks/sentinel-for-terraform
-            instruqt track test --skip-fail-check
             echo "Running instruqt track push..."
             instruqt track push --force
+            echo "Running instruqt track test..."
+            instruqt track test --skip-fail-check
 workflows:
   version: 2
   build-and-deploy:


### PR DESCRIPTION
This does an instruqt track push *before* testing, which makes more sense.  Testing before the push only tests the previous commit, not the current one.