### PR TITLE
Adds retry loop for `instruqt track test`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,14 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            instruqt track test --skip-fail-check
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 5
+            done
   instruqt-test-oss-azure:
     filters:
       branches:
@@ -94,7 +101,14 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            instruqt track test --skip-fail-check
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 5
+            done
   instruqt-test-cloud-aws:
     filters:
       branches:
@@ -126,7 +140,14 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            instruqt track test --skip-fail-check
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 5
+            done
   instruqt-test-cloud-azure:
     filters:
       branches:
@@ -158,7 +179,14 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            instruqt track test --skip-fail-check
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 5
+            done
   instruqt-test-cloud-gcp:
     filters:
       branches:
@@ -190,7 +218,14 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            instruqt track test --skip-fail-check
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 5
+            done
   instruqt-test-sentinel:
     filters:
       branches:
@@ -222,7 +257,14 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            instruqt track test --skip-fail-check
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 5
+            done
 workflows:
   version: 2
   build-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,50 +209,43 @@ workflows:
       - instruqt-validate:
           filters:
             branches:
-              only:
-                - master
+              only: master
       - instruqt-test-oss-aws:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only:
-                - master
+              only: master
       - instruqt-test-oss-azure:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only:
-                - master
+              only: master
       - instruqt-test-cloud-aws:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only:
-                - master
+              only: master
       - instruqt-test-cloud-azure:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only:
-                - master
+              only: master
       - instruqt-test-cloud-gcp:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only:
-                - master
+              only: master
       - instruqt-test-sentinel:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only:
-                - master
+              only: master
   nightly-build:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,14 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            instruqt track test --skip-fail-check
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 5
+            done
   instruqt-test-oss-azure:
     docker:
       - image: ubuntu:latest
@@ -85,7 +92,14 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            instruqt track test --skip-fail-check
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 5
+            done
   instruqt-test-cloud-aws:
     docker:
       - image: ubuntu:latest
@@ -114,7 +128,14 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            instruqt track test --skip-fail-check
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 5
+            done
   instruqt-test-cloud-azure:
     docker:
       - image: ubuntu:latest
@@ -143,7 +164,14 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            instruqt track test --skip-fail-check
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 5
+            done
   instruqt-test-cloud-gcp:
     docker:
       - image: ubuntu:latest
@@ -172,7 +200,14 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            instruqt track test --skip-fail-check
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 5
+            done
   instruqt-test-sentinel:
     docker:
       - image: ubuntu:latest
@@ -201,7 +236,14 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            instruqt track test --skip-fail-check
+            # Retry instruqt track test up to 3 times
+            n=0
+            until [ $n -ge 3 ]
+            do
+              instruqt track test --skip-fail-check && break
+              n=$[$n+1]
+              sleep 5
+            done
 workflows:
   version: 2
   build-and-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,6 @@
 version: 2
 jobs:
   instruqt-validate:
-    filters:
-      branches:
-        only: master
     docker:
       - image: ubuntu:latest
     steps:
@@ -32,9 +29,6 @@ jobs:
               cd $dir && instruqt track validate
             done
   instruqt-test-oss-aws:
-    filters:
-      branches:
-        only: master
     docker:
       - image: ubuntu:latest
     steps:
@@ -64,9 +58,6 @@ jobs:
             echo "Running instruqt track test..."
             instruqt track test --skip-fail-check
   instruqt-test-oss-azure:
-    filters:
-      branches:
-        only: master
     docker:
       - image: ubuntu:latest
     steps:
@@ -96,9 +87,6 @@ jobs:
             echo "Running instruqt track test..."
             instruqt track test --skip-fail-check
   instruqt-test-cloud-aws:
-    filters:
-      branches:
-        only: master
     docker:
       - image: ubuntu:latest
     steps:
@@ -128,9 +116,6 @@ jobs:
             echo "Running instruqt track test..."
             instruqt track test --skip-fail-check
   instruqt-test-cloud-azure:
-    filters:
-      branches:
-        only: master
     docker:
       - image: ubuntu:latest
     steps:
@@ -160,9 +145,6 @@ jobs:
             echo "Running instruqt track test..."
             instruqt track test --skip-fail-check
   instruqt-test-cloud-gcp:
-    filters:
-      branches:
-        only: master
     docker:
       - image: ubuntu:latest
     steps:
@@ -192,9 +174,6 @@ jobs:
             echo "Running instruqt track test..."
             instruqt track test --skip-fail-check
   instruqt-test-sentinel:
-    filters:
-      branches:
-        only: master
     docker:
       - image: ubuntu:latest
     steps:
@@ -230,43 +209,50 @@ workflows:
       - instruqt-validate
           filters:
             branches:
-              only: master
+              only:
+                - master
       - instruqt-test-oss-aws:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only: master
+              only:
+                - master
       - instruqt-test-oss-azure:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only: master
+              only:
+                - master
       - instruqt-test-cloud-aws:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only: master
+              only:
+                - master
       - instruqt-test-cloud-azure:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only: master
+              only:
+                - master
       - instruqt-test-cloud-gcp:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only: master
+              only:
+                - master
       - instruqt-test-sentinel:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only: master
+              only:
+                - master
   nightly-build:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,43 +209,50 @@ workflows:
       - instruqt-validate:
           filters:
             branches:
-              only: master
+              only:
+                - master
       - instruqt-test-oss-aws:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only: master
+              only:
+                - master
       - instruqt-test-oss-azure:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only: master
+              only:
+                - master
       - instruqt-test-cloud-aws:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only: master
+              only:
+                - master
       - instruqt-test-cloud-azure:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only: master
+              only:
+                - master
       - instruqt-test-cloud-gcp:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only: master
+              only:
+                - master
       - instruqt-test-sentinel:
           requires:
             - instruqt-validate
           filters:
             branches:
-              only: master
+              only:
+                - master
   nightly-build:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ workflows:
   version: 2
   build-and-deploy:
     jobs:
-      - instruqt-validate
+      - instruqt-validate:
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,14 +62,7 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            # Retry instruqt track test up to 3 times
-            n=0
-            until [ $n -ge 3 ]
-            do
-              instruqt track test --skip-fail-check && break
-              n=$[$n+1]
-              sleep 5
-            done
+            instruqt track test --skip-fail-check
   instruqt-test-oss-azure:
     filters:
       branches:
@@ -101,14 +94,7 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            # Retry instruqt track test up to 3 times
-            n=0
-            until [ $n -ge 3 ]
-            do
-              instruqt track test --skip-fail-check && break
-              n=$[$n+1]
-              sleep 5
-            done
+            instruqt track test --skip-fail-check
   instruqt-test-cloud-aws:
     filters:
       branches:
@@ -140,14 +126,7 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            # Retry instruqt track test up to 3 times
-            n=0
-            until [ $n -ge 3 ]
-            do
-              instruqt track test --skip-fail-check && break
-              n=$[$n+1]
-              sleep 5
-            done
+            instruqt track test --skip-fail-check
   instruqt-test-cloud-azure:
     filters:
       branches:
@@ -179,14 +158,7 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            # Retry instruqt track test up to 3 times
-            n=0
-            until [ $n -ge 3 ]
-            do
-              instruqt track test --skip-fail-check && break
-              n=$[$n+1]
-              sleep 5
-            done
+            instruqt track test --skip-fail-check
   instruqt-test-cloud-gcp:
     filters:
       branches:
@@ -218,14 +190,7 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            # Retry instruqt track test up to 3 times
-            n=0
-            until [ $n -ge 3 ]
-            do
-              instruqt track test --skip-fail-check && break
-              n=$[$n+1]
-              sleep 5
-            done
+            instruqt track test --skip-fail-check
   instruqt-test-sentinel:
     filters:
       branches:
@@ -257,37 +222,51 @@ jobs:
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
-            # Retry instruqt track test up to 3 times
-            n=0
-            until [ $n -ge 3 ]
-            do
-              instruqt track test --skip-fail-check && break
-              n=$[$n+1]
-              sleep 5
-            done
+            instruqt track test --skip-fail-check
 workflows:
   version: 2
   build-and-deploy:
     jobs:
       - instruqt-validate
+          filters:
+            branches:
+              only: master
       - instruqt-test-oss-aws:
           requires:
             - instruqt-validate
+          filters:
+            branches:
+              only: master
       - instruqt-test-oss-azure:
           requires:
             - instruqt-validate
+          filters:
+            branches:
+              only: master
       - instruqt-test-cloud-aws:
           requires:
             - instruqt-validate
+          filters:
+            branches:
+              only: master
       - instruqt-test-cloud-azure:
           requires:
             - instruqt-validate
+          filters:
+            branches:
+              only: master
       - instruqt-test-cloud-gcp:
           requires:
             - instruqt-validate
+          filters:
+            branches:
+              only: master
       - instruqt-test-sentinel:
           requires:
             - instruqt-validate
+          filters:
+            branches:
+              only: master
   nightly-build:
     triggers:
       - schedule:


### PR DESCRIPTION
Since instruqt track test often has temporary failures that are outside of our control, this PR adds a retry loop that tries to run the command again, up to three times.