### PR TITLE
Fixes script so it exits properly when creds are not fetched.

### DIFF
--- a/instruqt-tracks/terraform-build-azure/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-build-azure/setup-our-environment/setup-workstation
@@ -37,7 +37,7 @@ while read id secret; do
     echo "Error fetching Azure credentials. Please run the script again."
     exit 1
   fi
-done
+done || exit 1
 
 echo "\${grn}Ready to run Terraform on...\${end}"
 echo "${blu}"

--- a/instruqt-tracks/terraform-cloud-azure/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/setup-our-environment/setup-workstation
@@ -37,7 +37,7 @@ while read id secret; do
     echo "Error fetching Azure credentials. Please run the script again."
     exit 1
   fi
-done
+done || exit 1
 
 echo "\${grn}Ready to run Terraform on...\${end}"
 echo "${blu}"


### PR DESCRIPTION
Azure creds script should exit as soon as it has trouble fetching creds.