### PR TITLE
pin sentinel-for-terraform tag to 1

### DIFF
--- a/instruqt-tracks/sentinel-for-terraform/config.yml
+++ b/instruqt-tracks/sentinel-for-terraform/config.yml
@@ -1,5 +1,5 @@
 version: "2"
 containers:
 - name: sentinel
-  image: rberlind/sentinel-for-terraform:latest
+  image: rberlind/sentinel-for-terraform:1
   shell: /bin/sh

--- a/instruqt-tracks/sentinel-for-terraform/track.yml
+++ b/instruqt-tracks/sentinel-for-terraform/track.yml
@@ -520,4 +520,4 @@ challenges:
     hostname: sentinel
   difficulty: basic
   timelimit: 1800
-checksum: "10546822058937044550"
+checksum: "1440836311668485047"


### PR DESCRIPTION
This pins the tag of the sentinel-for-terraform docker image to "1" so that I can begin changing the docker image to use third-generation style Sentinel policies with the Terraform Sentinel v2 mocks and Sentinel modules for a second version of this Sentinel for Terraform workshop.

Previously, I had used the "latest" tag.  By having pushed a tag "1" and pinning the current version of the track to use that tag, I can work on the new version of the track without breaking the current version.