### PR TITLE
modified track.yml

### DIFF
--- a/instruqt-tracks/terraform-build-gcp/track.yml
+++ b/instruqt-tracks/terraform-build-gcp/track.yml
@@ -478,7 +478,7 @@ challenges:
     terraform plan
     ```
     <br>
-    Confirm the proper prefix is displayed in the plan output.
+    Confirm the proper prefix is displayed in the plan output.  Look for **# google_compute_network.hashicat** and find the output next to **+ name**.
 
     Then run `terraform apply` and watch your resources being built.
 


### PR DESCRIPTION
This applies the suggestion I mention in the issue ticket for the assareh-add-tf-oss-gcp track.

Terraform Apply
"Confirm the proper prefix is displayed in the plan output"
Add instructions to looking within the "# google_compute_network.hashicat" output next to "+ name"