### PR TITLE
Misc fixes for OSS tracks and instructor guides

### DIFF
--- a/instructor-guides/aws_intro_to_terraform_INSTRUCTOR_GUIDE.md
+++ b/instructor-guides/aws_intro_to_terraform_INSTRUCTOR_GUIDE.md
@@ -91,7 +91,7 @@ Scroll through the main.tf file and point out some of the resources that are bei
 
 Run an apply with some different variables:
 ```
-terraform apply -auto-approve -var height=1000 width=1200
+terraform apply -auto-approve -var height=1000 -var width=1200
 ```
 
 > This terraform code has been optimized to re-deploy our application on every run. What's happening now is terraform is checking the state of my network, security groups, and vm settings. In the real world you probably would not use Terraform in this way (forcing a redeploy of the application every run). But for demo and learning purposes it helps us get some practice running terraform apply and seeing instant feedback.

--- a/instructor-guides/azure_intro_to_terraform_INSTRUCTOR_GUIDE.md
+++ b/instructor-guides/azure_intro_to_terraform_INSTRUCTOR_GUIDE.md
@@ -94,7 +94,7 @@ Scroll through the main.tf file and point out some of the resources that are bei
 
 Run an apply with some different variables:
 ```
-terraform apply -auto-approve -var height=1000 width=1200
+terraform apply -auto-approve -var height=1000 -var width=1200
 ```
 
 > This terraform code has been optimized to re-deploy our application on every run. What's happening now is terraform is checking the state of my network, security groups, and vm settings. In the real world you probably would not use Terraform in this way (forcing a redeploy of the application every run). But for demo and learning purposes it helps us get some practice running terraform apply and seeing instant feedback.

--- a/instruqt-tracks/terraform-build-aws/track.yml
+++ b/instruqt-tracks/terraform-build-aws/track.yml
@@ -161,7 +161,7 @@ challenges:
   title: "\U0001F510 Connecting Terraform to AWS"
   teaser: Connecting to AWS with Access Keys and Secret Keys.
   assignment: |-
-    In order to authenticate to AWS and build resources, Terraform requires you to provide a set of credntials, backed by an appropriate IAM policy.
+    In order to authenticate to AWS and build resources, Terraform requires you to provide a set of credentials, backed by an appropriate IAM policy.
 
     For this training environment, we have prepared some temporary AWS credentials and stored them as environment variables. Terraform will automatically read and use the environment variables that are configured in your shell environment.
 
@@ -489,7 +489,7 @@ challenges:
     terraform graph
     ```
 
-    This generates code that can be used to create a visual map of your infrastructure. The graph data is in [DOT graph description language format](https://en.wikipedia.org/wiki/DOT_(graph_description_language). There are several graphing tools you can use to visualize this data, including the free Blast Radius tool. You can learn more about Blast Radius here:
+    This generates code that can be used to create a visual map of your infrastructure. The graph data is in [DOT graph description language format](https://en.wikipedia.org/wiki/DOT_(graph_description_language)). There are several graphing tools you can use to visualize this data, including the free Blast Radius tool. You can learn more about Blast Radius here:
 
     https://28mm.github.io/blast-radius-docs/
 
@@ -652,7 +652,7 @@ challenges:
 - slug: add-a-tag
   id: 8g5jn5a3mxam
   type: challenge
-  title: "\U0001F3F7️ Add a Tag to Your Resource Group"
+  title: "\U0001F3F7️ Add a Tag to Your VPC"
   teaser: Terraform can change some resources in in place without deleting them. Adding
     tags is a non-destructive action.
   assignment: |-
@@ -725,7 +725,7 @@ challenges:
   id: hnlvhqi0wjdq
   type: challenge
   title: "\U0001F3D7️ Complete the Build"
-  teaser: Terraform code can stand up everything from resource groups, to virtual
+  teaser: Terraform code can stand up everything from VPCs, to virtual
     networks, to VMs and containers.
   assignment: |-
     We've uncommented all the rest of the Terraform code in the **main.tf** file for you. Run a `terraform plan` to see what will be built:
@@ -1023,7 +1023,7 @@ challenges:
   teaser: Terraform Cloud offers unlimited free Terraform state storage for users.
     Safeguard your state files by storing them remotely in Terraform Cloud.
   assignment: |-
-    During this challenge you'll use the free remote state feature of Terraform Cloud to store your state file. In order to do this you'll need a free Terraform Cloud account. Click on the URL below and sign up for an account if you don't have one already:
+    During this challenge and the next one, you'll use the remote state feature of Terraform Cloud to store your state file in the cloud. In order to do this you'll need a Terraform Cloud account. Click on the URL below and sign up for a free account if you don't have one already:
 
     https://app.terraform.io/signup/account
 
@@ -1033,31 +1033,7 @@ challenges:
 
     Next you'll be prompted to create a workspace. You can skip the VCS integration step by clicking the "No VCS Connection" button. Name your workspace **hashicat-aws**.
 
-    Now go into the workspace's **Settings >> General** settings page and change the Execution Mode to local. Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables.
-
-    Return to your Code Editor tab and edit the `remote_backend.tf` file, replacing the YOURORGANIZATION and YOURWORKSPACE placeholders with your org name and workspace name. Save the file.
-
-    Use the `terraform login` command to generate and save your token in a local config file. You can simply follow the instructions in your terminal after you run this command. All of the defaults are fine:
-
-    ```
-    terraform login
-    ```
-
-    NOTE: You won't see your token appear on the screen when you copy and paste it into the terminal. This is expected.
-
-    Your token is now safely stored in the `/root/.terraform.d/credentials.tfrc.json` file.
-
-    Now run `terraform init` to migrate your state to Terraform Cloud.
-
-    ```
-    terraform init
-    ```
-
-    Type "yes" when it prompts you to migrate your state into Terraform Cloud.
-
-    Your state is now safely stored in Terraform Cloud.
-
-    Run another `terraform apply -auto-approve` and watch your state file evolve with each change. You can browse through previous state files with the Terraform Cloud UI.
+    Now go into the workspace's **Settings >> General** settings page and change the Execution Mode to local. Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
   notes:
   - type: text
     contents: Terraform Cloud remote state storage is free for all users.
@@ -1082,27 +1058,31 @@ challenges:
   teaser: The terraform command line tool can store its state in Terraform Cloud.
     All that is required is a user token.
   assignment: |-
-    In the Terraform Cloud web UI, go into your Terraform Cloud User Settings by clicking the icon in the upper right corner. Under User Settings click on Tokens. Generate a new token for your workstation. You can call it **workshop-token**. Copy this token for the next step.
+    During this challenge we'll configure Terraform Cloud as a remote state backend, and then migrate our existing state file to Terraform Cloud.
 
-    Use the `terraform login` command to save your token in a local config file:
+    Edit the `remote_backend.tf` file and replace the YOURORGANIZATION and YOURWORKSPACE placeholders with your org name and workspace name.
+
+    Use the `terraform login` command to generate and save your token in a local config file. You can simply follow the instructions in your terminal after you run this command. All of the defaults are fine:
 
     ```
     terraform login
     ```
+    <br>
+    NOTE: You won't see your token appear on the screen when you copy and paste it into the terminal. This is expected.
 
     Your token is now safely stored in the `/root/.terraform.d/credentials.tfrc.json` file.
 
-    Now run `terraform init` to migrate your state to Terraform Cloud:
+    Now run `terraform init` to migrate your state to Terraform Cloud.
 
     ```
     terraform init
     ```
-
+    <br>
     Type "yes" when it prompts you to migrate your state into Terraform Cloud.
 
     Your state is now safely stored in Terraform Cloud.
 
-    Run another `terraform apply -auto-approve` and watch your state file evolve with each change. You can browse through previous state files with the Terraform Cloud UI.
+    Run a `terraform apply -auto-approve` and watch your state file evolve with each change. You can browse through previous state files with the Terraform Cloud UI.
   notes:
   - type: text
     contents: |-

--- a/instruqt-tracks/terraform-build-azure/track.yml
+++ b/instruqt-tracks/terraform-build-azure/track.yml
@@ -488,7 +488,7 @@ challenges:
     terraform graph
     ```
 
-    This generates code that can be used to create a visual map of your infrastructure. The graph data is in [DOT graph description language format](https://en.wikipedia.org/wiki/DOT_(graph_description_language). There are several graphing tools you can use to visualize this data, including the free Blast Radius tool. You can learn more about Blast Radius here:
+    This generates code that can be used to create a visual map of your infrastructure. The graph data is in [DOT graph description language format](https://en.wikipedia.org/wiki/DOT_(graph_description_language)). There are several graphing tools you can use to visualize this data, including the free Blast Radius tool. You can learn more about Blast Radius here:
 
     https://28mm.github.io/blast-radius-docs/
 
@@ -1029,17 +1029,17 @@ challenges:
   teaser: Terraform Cloud offers unlimited free Terraform state storage for users.
     Safeguard your state files by storing them remotely in Terraform Cloud.
   assignment: |-
-    Sign up for a free Terraform Cloud account at the following URL:
+    During this challenge and the next one, you'll use the remote state feature of Terraform Cloud to store your state file in the cloud. In order to do this you'll need a Terraform Cloud account. Click on the URL below and sign up for a free account if you don't have one already:
 
     https://app.terraform.io/signup/account
 
     If you already have an account you can simply sign in with your existing credentials.
 
-    Once you're signed into Terraform Cloud create a new organization called YOURNAME-sandbox. Replace YOURNAME with your own name or other text.
+    Once you're signed into Terraform Cloud create a new organization called YOURNAME-training. Replace YOURNAME with your own name or other text.
 
-    Next you'll be prompted to create a workspace. You can skip the VCS integration step by clicking the "No VCS Connection" button. Name your workspace **hashicat**.
+    Next you'll be prompted to create a workspace. You can skip the VCS integration step by clicking the "No VCS Connection" button. Name your workspace **hashicat-azure**.
 
-    Now go into the workspace's **Settings >> General** settings page and change the Execution Mode to local.  Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables.
+    Now go into the workspace's **Settings >> General** settings page and change the Execution Mode to local. Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
   notes:
   - type: text
     contents: Terraform Cloud remote state storage is free for all users.
@@ -1064,26 +1064,16 @@ challenges:
   teaser: The Terraform command line tool can store its state in Terraform Cloud.
     All that is required is a user token.
   assignment: |-
-    During this challenge you'll use the free remote state feature of Terraform Cloud to store your state file. In order to do this you'll need a free Terraform Cloud account. Click on the URL below and sign up for an account if you don't have one already:
+    During this challenge we'll configure Terraform Cloud as a remote state backend, and then migrate our existing state file to Terraform Cloud.
 
-    https://app.terraform.io/signup/account
-
-    If you already have an account you can simply sign in with your existing credentials.
-
-    Once you're signed into Terraform Cloud create a new organization called YOURNAME-training. Replace YOURNAME with your own name or other text.
-
-    Next you'll be prompted to create a workspace. You can skip the VCS integration step by clicking the "No VCS Connection" button. Name your workspace **hashicat-azure**.
-
-    Now go into the workspace's **Settings >> General** settings page and change the Execution Mode to local. Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables.
-
-    Return to your Code Editor tab and edit the `remote_backend.tf` file, replacing the YOURORGANIZATION and YOURWORKSPACE placeholders with your org name and workspace name. Save the file.
+    Edit the `remote_backend.tf` file and replace the YOURORGANIZATION and YOURWORKSPACE placeholders with your org name and workspace name.
 
     Use the `terraform login` command to generate and save your token in a local config file. You can simply follow the instructions in your terminal after you run this command. All of the defaults are fine:
 
     ```
     terraform login
     ```
-
+    <br>
     NOTE: You won't see your token appear on the screen when you copy and paste it into the terminal. This is expected.
 
     Your token is now safely stored in the `/root/.terraform.d/credentials.tfrc.json` file.
@@ -1093,12 +1083,12 @@ challenges:
     ```
     terraform init
     ```
-
+    <br>
     Type "yes" when it prompts you to migrate your state into Terraform Cloud.
 
     Your state is now safely stored in Terraform Cloud.
 
-    Run another `terraform apply -auto-approve` and watch your state file evolve with each change. You can browse through previous state files with the Terraform Cloud UI.
+    Run a `terraform apply -auto-approve` and watch your state file evolve with each change. You can browse through previous state files with the Terraform Cloud UI.
   notes:
   - type: text
     contents: |-

--- a/instruqt-tracks/terraform-build-gcp/track.yml
+++ b/instruqt-tracks/terraform-build-gcp/track.yml
@@ -477,8 +477,8 @@ challenges:
     ```
     terraform plan
     ```
-    <br>
-    Confirm the proper prefix is displayed in the plan output.  Look for **# google_compute_network.hashicat** and find the output next to **+ name**.
+
+    Confirm the proper prefix is displayed in the plan output. Look for **# google_compute_network.hashicat** and find the output next to **+ name**.
 
     Then run `terraform apply` and watch your resources being built.
 
@@ -745,7 +745,7 @@ challenges:
     "cowsay Mooooooooooo!",
     ```
 
-    Now run another `terraform apply` to apply your changes:
+    Now run another `terraform apply -auto-approve` to apply your changes:
 
     ```
     terraform apply -auto-approve
@@ -848,7 +848,7 @@ challenges:
     export TF_VAR_placeholder=placedog.net
     ```
 
-    Run another `terraform apply` command:
+    Run another `terraform apply -auto-approve` command:
     ```
     terraform apply -auto-approve
     ```
@@ -922,7 +922,7 @@ challenges:
   teaser: Terraform Cloud offers unlimited free Terraform state storage for users.
     Safeguard your state files by storing them remotely in Terraform Cloud.
   assignment: |-
-    During this challenge and the next one you'll use the remote state feature of Terraform Cloud to store your state file. In order to do this you'll need a Terraform Cloud account. Click on the URL below and sign up for a free account if you don't have one already:
+    During this challenge and the next one, you'll use the remote state feature of Terraform Cloud to store your state file in the cloud. In order to do this you'll need a Terraform Cloud account. Click on the URL below and sign up for a free account if you don't have one already:
 
     https://app.terraform.io/signup/account
 
@@ -1038,4 +1038,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1000
-checksum: "13174136683256592501"
+checksum: "12239207304498755792"


### PR DESCRIPTION
**OSS on AWS:**

- Fixed ‘credntials’ typo
- Fixed TFC setup and Remote State exercises had duplicate content (copied across so all three OSS tracks are consistent)
- Removed mentions of ‘resource group’ (changed to VPC)
- Corrected DOT graph Wikipedia link (missing a close paren)

**OSS on Azure:**

- Fixed TFC setup and Remote State exercises had duplicate content (copied across so all three OSS tracks are consistent)
- Corrected DOT graph Wikipedia link (missing a close paren)

**OSS on GCP:**

- Corrected formatting in terraform apply exercise

**Instructor Guides:**

- Corrected a demo command in AWS and Azure OSS Instructor Guides (missing a -var)