### PR TITLE
removed "Windows" or "Mac" differences

### DIFF
--- a/instruqt-tracks/terraform-build-gcp/track.yml
+++ b/instruqt-tracks/terraform-build-gcp/track.yml
@@ -70,11 +70,11 @@ challenges:
   teaser: Terraform commands are run from a terminal window. Terraform can be installed
     on Linux, Windows, or MacOS.
   assignment: |-
-    Click on the Main Menu and select **Terminal > New Terminal** or use the keyboard shortcut **CTRL-`** (Windows) or **CMD-`** (Mac). That is a backtick character, usually found in the upper left corner of your keyboard.
+    Click on the Main Menu and select **Terminal > New Terminal** or use the keyboard shortcut **CTRL-`** which is a backtick character usually found in the upper left corner of your keyboard.
 
     All Terraform commands should be run from the terminal within the Code Editor.  Make sure you are in the hashicat-gcp directory when you run terraform commands.
 
-    Try the **CTRL-`** (**CMD-`** for Mac) shortcut to toggle the terminal panel open and closed.
+    Try the **CTRL-`** shortcut to toggle the terminal panel open and closed.
 
     You can use the little caret ^ shaped button on the terminal pane to expand and shrink your Terminal window. This is useful for viewing logs.
 


### PR DESCRIPTION
CTRL+` to open the embedded terminal is the same keyboard shortcut for both Windows and Mac.