### PR TITLE
Adds a shell tab to each cloud track.

### DIFF
--- a/instruqt-tracks/terraform-cloud-aws/track.yml
+++ b/instruqt-tracks/terraform-cloud-aws/track.yml
@@ -74,6 +74,9 @@ challenges:
     type: code
     hostname: workstation
     path: /root/hashicat-aws
+  - title: Shell
+    type: terminal
+    hostname: workstation
   difficulty: basic
   timelimit: 1800
 - slug: open-a-terminal

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -74,6 +74,9 @@ challenges:
     type: code
     hostname: workstation
     path: /root/hashicat-azure
+  - title: Shell
+    type: terminal
+    hostname: workstation
   difficulty: basic
   timelimit: 1800
 - slug: open-a-terminal

--- a/instruqt-tracks/terraform-cloud-gcp/track.yml
+++ b/instruqt-tracks/terraform-cloud-gcp/track.yml
@@ -74,6 +74,9 @@ challenges:
     type: code
     hostname: workstation
     path: /root
+  - title: Shell
+    type: terminal
+    hostname: workstation
   difficulty: basic
   timelimit: 1800
 - slug: open-a-terminal

--- a/instruqt-tracks/terraform-module-lab/track.yml
+++ b/instruqt-tracks/terraform-module-lab/track.yml
@@ -54,6 +54,9 @@ challenges:
     type: code
     hostname: workstation
     path: /root/workspace
+  - title: Shell
+    type: terminal
+    hostname: workstation
   difficulty: basic
   timelimit: 7200
 - slug: terraform-cloud-setup


### PR DESCRIPTION
This exposes a terminal for the first challenge, so that students have a place to run the `fastforward` command if they need to.