### PR TITLE
add term tab and fix line # in validate challenge

### DIFF
--- a/instruqt-tracks/terraform-build-azure/config.yml
+++ b/instruqt-tracks/terraform-build-azure/config.yml
@@ -3,13 +3,10 @@ virtualmachines:
 - name: workstation
   image: instruqt-hashicorp/terraform-workstation-prod
   shell: /bin/bash
-  machine_type: n1-standard-1
-  ports:
-  - 8443
-  - 5000
   environment:
     ARM_SUBSCRIPTION_ID: 14692f20-9428-451b-8298-102ed4e39c2a
     ARM_TENANT_ID: 0e3e2e88-8caf-41ca-b4da-e3b33b6c52ec
     VAULT_ADDR: https://cam-vault.hashidemos.io:8200
     VAULT_CREDS_ENDPOINT: azure/creds/se-training-workstation
     VAULT_NAMESPACE: Sales/SE
+  machine_type: n1-standard-1

--- a/instruqt-tracks/terraform-build-azure/track.yml
+++ b/instruqt-tracks/terraform-build-azure/track.yml
@@ -98,6 +98,9 @@ challenges:
     type: code
     hostname: workstation
     path: /root/hashicat-azure
+  - title: Shell
+    type: terminal
+    hostname: workstation
   difficulty: basic
   timelimit: 1000
 - slug: hello-terraform
@@ -308,7 +311,7 @@ challenges:
 
     Click on the File Explorer icon on the left. It looks like a stack of papers.
 
-    Edit the main.tf file and remove the curly brace on line 4 of the file.
+    Edit the main.tf file and remove the double quotes between `azurerm_resource_group` and `myresourcegroup` on line 5 of the file, keeping the space that was between them.
 
     Validate your code:
 
@@ -316,7 +319,7 @@ challenges:
     terraform validate
     ```
 
-    Now put the curly brace back onto line 4 and run the validate command again. This time you should pass the validation test.
+    Now put the double quotes back in line 5 and run the validate command again. This time you should pass the validation test.
 
     **terraform validate** is most often used in automated CI/CD test pipelines. It allows you to quickly catch errors in your code before any other steps are taken.
   notes:
@@ -751,8 +754,8 @@ challenges:
     Open your web application in a new browser tab. You'll need to copy and paste the URL into your address bar.
   notes:
   - type: text
-    contents: The `-auto-approve` flag can be used to override the "Are you sure?" questions
-      that appear before an apply or destroy. Use with caution!
+    contents: The `-auto-approve` flag can be used to override the "Are you sure?"
+      questions that appear before an apply or destroy. Use with caution!
   tabs:
   - title: Code Editor
     type: service
@@ -1143,4 +1146,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1000
-checksum: "8825588920583286730"
+checksum: "338305656444026146"


### PR DESCRIPTION
add terminal tab to terraform-build-azure challenge 2.
Change line 4 to line 5 in validate challenge instructions and change what to do to give nice clean error
(Remove double quotes between resource type and name instead of removing single brace)