### PR TITLE
better check for generated azure creds

### DIFF
--- a/instruqt-tracks/terraform-build-azure/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-build-azure/setup-our-environment/setup-workstation
@@ -31,13 +31,13 @@ end=$'\e[0m'
 # Requires \$VAULT_ADDR, \$VAULT_NAMESPACE, \$VAULT_CREDS_ENDPOINT and \$VAULT_TOKEN to be set as environment variables
 
 # Regex matching the shape of Azure credentials
-AZURE_REGEX="[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}"
+AZURE_ID_REGEX="[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}"
 
 echo "Fetching dynamic Azure credentials from \${VAULT_ADDR}/v1/\${VAULT_CREDS_ENDPOINT}"
 curl -s --retry 5 -H "X-Vault-Token: \${VAULT_TOKEN}" -H "X-Vault-Namespace: \$VAULT_NAMESPACE" \${VAULT_ADDR}/v1/\${VAULT_CREDS_ENDPOINT} | \
 jq -r '[.data.client_id,.data.client_secret] | @tsv' | \
 while read id secret; do
-  if [[ \$id =~ \$AZURE_REGEX ]] && [[ \$secret =~ \$AZURE_REGEX ]]; then
+  if [[ \$id =~ \$AZURE_ID_REGEX ]]; then
     echo "Valid Azure credentials received. Testing them now..."
     until \$(az login --service-principal --username=\$id --password=\$secret --tenant=\$ARM_TENANT_ID > /dev/null 2>&1); do
       echo "Waiting for Azure credentials to be ready..."

--- a/instruqt-tracks/terraform-build-azure/track.yml
+++ b/instruqt-tracks/terraform-build-azure/track.yml
@@ -1155,4 +1155,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1000
-checksum: "10449430474764479960"
+checksum: "6756001926744914819"

--- a/instruqt-tracks/terraform-cloud-azure/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/setup-our-environment/setup-workstation
@@ -24,13 +24,13 @@ end=$'\e[0m'
 # Requires \$VAULT_ADDR, \$VAULT_NAMESPACE, \$VAULT_CREDS_ENDPOINT and \$VAULT_TOKEN to be set as environment variables
 
 # Regex matching the shape of Azure credentials
-AZURE_REGEX="[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}"
+AZURE_ID_REGEX="[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}"
 
 echo "Fetching dynamic Azure credentials from \${VAULT_ADDR}/v1/\${VAULT_CREDS_ENDPOINT}"
 curl -s --retry 5 -H "X-Vault-Token: \${VAULT_TOKEN}" -H "X-Vault-Namespace: \$VAULT_NAMESPACE" \${VAULT_ADDR}/v1/\${VAULT_CREDS_ENDPOINT} | \
 jq -r '[.data.client_id,.data.client_secret] | @tsv' | \
 while read id secret; do
-  if [[ true ]]; then
+  if [[ \$id =~ \$AZURE_ID_REGEX ]]; then
     echo "Valid Azure credentials received. Testing them now..."
     until \$(az login --service-principal --username=\$id --password=\$secret --tenant=\$ARM_TENANT_ID > /dev/null 2>&1); do
       echo "Waiting for Azure credentials to be ready..."

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -848,4 +848,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1800
-checksum: "15535067165371807845"
+checksum: "8753687154383639764"


### PR DESCRIPTION
This gives a better fix for checking azure creds generated by the CAM Vault cluster after it was upgraded to Vault 1.5.
The problem was that Vault 1.5 no longer generates standard Azure client_secret (password).  Instead of matching the regex pattern, "[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}", it now gives a 36-character alphanumeric string with lowercase and uppercase letters and numbers, but no hyphens.  This is related to Vault 1.5's introduction of Password Policies: https://www.vaultproject.io/docs/concepts/password-policies.  Unfortunately, according to https://www.vaultproject.io/api-docs/secret/azure#password_policy, if no password policy is specified, an alphanumeric string will be used.  But that is not standard Azure and broke the script. I have opened https://app.asana.com/0/1182317814772514/1190899161289107 requesting fixes in Vault.

The initial fix was to simply replace the original regex checks on the client_id and client_secret with `true`.  But that effectively made the check always pass regardless of what Azure creds were generated by Vault.

My change is to change the original code which was `if [[ \$id =~ \$AZURE_REGEX ]] && [[ \$secret =~ \$AZURE_REGEX ]]; then` to `if [[ \$id =~ \$AZURE_ID_REGEX ]]; then`.  Effectively, I dropped the regex check on the secret.

I could have added a check that would check for a 36-character alphanumeric string.  But I would rather not do that because if Vault does change the default password format for the Azure secrets engine in the future as I have requested, that would break the script and we could then have a future surprise breakage in these Terraform for Azure workshops.

I think validating that we got a valid client_id from Vault suffices and will avoid future problems.

I did make one more change, changing AZURE_REGEX to AZURE_ID_REGEX since is is now only applied to the ID.  In the future, we could add an AZURE_SECRET_REGEX if we learn that the Vault team will not change the default secret back to the standard format.