### PR TITLE
add Sentinel for Terraform v3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,7 +301,7 @@ jobs:
               echo "Instruqt track test failed three times."
               exit 1
             fi
-  instruqt-test-sentinel-v1:
+  instruqt-test-sentinel-v3:
     docker:
       - image: ubuntu:latest
     steps:
@@ -325,7 +325,7 @@ jobs:
             else
               echo "Instruqt is installed and updated to most recent version."
             fi
-            cd /root/project/instruqt-tracks/sentinel-for-terraform-v1
+            cd /root/project/instruqt-tracks/sentinel-for-terraform-v3
             echo "Running instruqt track push..."
             instruqt track push --force
             echo "Running instruqt track test..."
@@ -437,7 +437,7 @@ workflows:
             branches:
               only:
                 - master
-      - instruqt-test-sentinel-v1:
+      - instruqt-test-sentinel-v3:
           requires:
             - instruqt-validate
           filters:
@@ -482,7 +482,7 @@ workflows:
       - instruqt-test-sentinel-cli-basics:
           requires:
             - instruqt-validate
-      - instruqt-test-sentinel-v1:
+      - instruqt-test-sentinel-v3:
           requires:
             - instruqt-validate
       - instruqt-test-sentinel-v2:

--- a/instruqt-tracks/sentinel-for-terraform-v2/exercise-2/check-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v2/exercise-2/check-sentinel
@@ -2,10 +2,10 @@
 
 set -e
 
-# Create /tmp/skip-check to disable this check
+# Run 'touch /tmp/skip-check' to disable this check
 if [ -f /tmp/skip-check ]; then
-    rm /tmp/skip-check
-    exit 0
+  rm /tmp/skip-check
+  exit 0
 fi
 
 cd /root/sentinel
@@ -36,7 +36,7 @@ grep -q "pgp_key is null" require-access-keys-use-pgp-2.sentinel || grep -q "pgp
 
 grep -qL "<condition_2>" require-access-keys-use-pgp-1.sentinel && fail-message "You have not replaced '<condition_2>' in require-access-keys-use-pgp-2.sentinel yet."
 
-grep -q 'not strings.has_prefix(.*pgp_key.*,.*"keybase:")' require-access-keys-use-pgp-2.sentinel || fail-message "You have not replaced '<condition_2>' with 'not strings.has_prefix(pgp_key, "keybase:")' in require-access-keys-use-pgp-2.sentinel yet."
+grep -q 'not strings.has_prefix(.*pgp_key.*,.*"keybase:")' require-access-keys-use-pgp-2.sentinel || fail-message "You have not replaced '<condition_2>' with 'not strings.has_prefix(pgp_key, \"keybase:\")' in require-access-keys-use-pgp-2.sentinel yet."
 
 grep -q "cp require-access-keys-use-pgp-2.sentinel require-access-keys-use-pgp.sentinel" /root/.bash_history || fail-message "You have not copied require-access-keys-use-pgp-2.sentinel to require-access-keys-use-pgp.sentinel yet."
 

--- a/instruqt-tracks/sentinel-for-terraform-v2/exercise-3/check-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v2/exercise-3/check-sentinel
@@ -2,10 +2,10 @@
 
 set -e
 
-# Create /tmp/skip-check to disable this check
+# Run 'touch /tmp/skip-check' to disable this check
 if [ -f /tmp/skip-check ]; then
-    rm /tmp/skip-check
-    exit 0
+  rm /tmp/skip-check
+  exit 0
 fi
 
 cd /root/sentinel

--- a/instruqt-tracks/sentinel-for-terraform-v2/exercise-4/check-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v2/exercise-4/check-sentinel
@@ -2,10 +2,10 @@
 
 set -e
 
-# Create /tmp/skip-check to disable this check
+# Run 'touch /tmp/skip-check' to disable this check
 if [ -f /tmp/skip-check ]; then
-    rm /tmp/skip-check
-    exit 0
+  rm /tmp/skip-check
+  exit 0
 fi
 
 cd /root/sentinel

--- a/instruqt-tracks/sentinel-for-terraform-v3/config.yml
+++ b/instruqt-tracks/sentinel-for-terraform-v3/config.yml
@@ -1,0 +1,6 @@
+version: "2"
+virtualmachines:
+- name: sentinel
+  image: instruqt-hashicorp/ubuntu-base
+  shell: /bin/bash -l
+  machine_type: n1-standard-1

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-1/check-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-1/check-sentinel
@@ -1,0 +1,55 @@
+#!/bin/bash -l
+
+set -e
+
+# Run 'touch /tmp/skip-check' to disable this check
+if [ -f /tmp/skip-check ]; then
+  rm /tmp/skip-check
+  exit 0
+fi
+
+cd /root/sentinel
+
+grep -qL "<method1>" restrict-vault-auth-methods.sentinel && fail-message "You have not replaced '<method1>' in restrict-vault-auth-methods.sentinel yet."
+
+grep -q "azure" restrict-vault-auth-methods.sentinel || fail-message "You have not added 'azure' to the allowed_methods list yet."
+
+grep -qL "<method2>" restrict-vault-auth-methods.sentinel && fail-message "You have not replaced '<method2>' in restrict-vault-auth-methods.sentinel yet."
+
+grep -q "kubernetes" restrict-vault-auth-methods.sentinel || fail-message "You have not added 'kubernetes' to the allowed_methods list yet."
+
+grep -qL "<method3>" restrict-vault-auth-methods.sentinel && fail-message "You have not replaced '<method3>' in restrict-vault-auth-methods.sentinel yet."
+
+grep -q "github" restrict-vault-auth-methods.sentinel || fail-message "You have not added 'github' to the allowed_methods list yet."
+
+grep -qL "<method4>" restrict-vault-auth-methods.sentinel && fail-message "You have not replaced '<method4>' in restrict-vault-auth-methods.sentinel yet."
+
+grep -q "approle" restrict-vault-auth-methods.sentinel || fail-message "You have not added 'approle' to the allowed_methods list yet."
+
+grep -qL "<resource_type>" restrict-vault-auth-methods.sentinel && fail-message "You have not replaced '<resource_type>' in restrict-vault-auth-methods.sentinel yet."
+
+grep -q "vault_auth_backend" restrict-vault-auth-methods.sentinel || fail-message "You have not replaced '<resource_type>' with 'vault_auth_backend' yet."
+
+grep -qL "<attribute>" restrict-vault-auth-methods.sentinel && fail-message "You have not replaced '<attribute>' in restrict-vault-auth-methods.sentinel yet."
+
+matches=$(grep type restrict-vault-auth-methods.sentinel | wc -l)
+if [ $matches -ne 1 ]; then
+    fail-message "You have not replaced '<attribute>' with 'type' yet."
+fi
+
+grep -qL "<list>" restrict-vault-auth-methods.sentinel && fail-message "You have not replaced '<list>' in restrict-vault-auth-methods.sentinel yet."
+
+matches=$(grep allowed_methods restrict-vault-auth-methods.sentinel | wc -l)
+if [ $matches -ne 2 ]; then
+    fail-message "You have not replaced '<list>' with 'allowed_methods' yet."
+fi
+
+grep -q "sentinel test -run=vault -verbose" /root/.bash_history || grep -q "sentinel test -run=vault" /root/.bash_history || fail-message "You haven't tested the restrict-vault-auth-methods.sentinel policy against the test cases yet. Please run 'sentinel test -run=vault -verbose'"
+
+sentinel test -run=vault
+rc=$?
+if [ $rc -ne 0 ]; then
+    fail-message "Your policy did not pass both test cases. Please revise and test it again."
+fi
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-1/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-1/setup-sentinel
@@ -1,0 +1,1764 @@
+#!/bin/bash -l
+
+set -e
+
+mkdir -p /root/sentinel
+echo "cd /root/sentinel" >> /root/.profile
+
+# Install Sentinel
+SENTINEL_VERSION=0.15.2
+wget https://releases.hashicorp.com/sentinel/${SENTINEL_VERSION}/sentinel_${SENTINEL_VERSION}_linux_amd64.zip
+unzip -d /bin sentinel_${SENTINEL_VERSION}_linux_amd64.zip
+rm sentinel_${SENTINEL_VERSION}_linux_amd64.zip
+
+# common-functions
+mkdir -p /root/sentinel/common-functions/tfplan-functions
+mkdir -p /root/sentinel/common-functions/tfstate-functions
+
+cat <<-'EOF' > /root/sentinel/common-functions/tfplan-functions/tfplan-functions.sentinel
+# Common functions that use the tfplan/v2 import
+
+# The filter functions all accept a collection of resource changes, an attribute,
+# a value or a list of values, and a boolean, prtmsg, which can be true or false
+# and indicates whether the filter function should print violation messages.
+# The filter functions return a map consisting of 2 items:
+#   * "resources": a map consisting of resource changes that violate a condition
+#   * "messages":  a map of violation messages associated with the resources
+# Note that both the resources and messages collections are indexed by the
+# address of the resources, so they will have the same order and length.
+# The filter functions all call evaluate_attribute() to evaluate attributes
+# of resources even if nested deep within them.
+
+##### Imports #####
+import "tfplan/v2" as tfplan
+import "strings"
+import "types"
+
+##### Functions #####
+
+### find_resources ###
+# Find all resources of a specific type using the tfplan/v2 import.
+# Only include resources that are being created or updated.
+# Technically, this returns a map of resource changes.
+find_resources = func(type) {
+  resources = filter tfplan.resource_changes as address, rc {
+  	rc.type is type and
+  	rc.mode is "managed" and
+  	(rc.change.actions contains "create" or rc.change.actions contains "update")
+  }
+
+  return resources
+}
+
+### find_datasources ###
+# Find all data sources of a specific type using the tfplan/v2 import.
+# Only include data sources that are being created, updated, or read.
+# Technically, this returns a map of resource changes.
+find_datasources = func(type) {
+  datasources = filter tfplan.resource_changes as address, rc {
+  	rc.type is type and
+  	rc.mode is "data" and
+  	(rc.change.actions contains "create" or
+    rc.change.actions contains "update" or
+    rc.change.actions contains "read")
+  }
+
+  return datasources
+}
+
+### find_blocks ###
+# Find all blocks of a specific type from a resource using the tfplan/v2 import.
+# parent should be a single resource or block of a resource or a data source
+# or a block of a data source.
+# If parent is a resource, you can pass it in the form rc.change.after or just rc.
+# child should be a string representing a block of parent
+# that contains a list of objects.
+find_blocks = func(parent, child) {
+  # Use parent.change.after if it exists
+  if (types.type_of(parent) is "map" and
+     "change" in keys(parent)) and
+     (types.type_of(parent.change) is "map" and
+     "after" in keys(parent.change)) {
+    if types.type_of(parent.change.after[child] else null) is "list" {
+      return parent.change.after[child]
+    } else {
+      return []
+    }
+  } else {
+    if types.type_of(parent[child] else null) is "list" {
+  	  return parent[child]
+    } else {
+      return []
+    }
+  }
+}
+
+### to_string ###
+# Convert objects of unknown type to string
+# It is used to build messages added to the messages map returned by the
+# filter functions
+to_string = func(obj) {
+  case types.type_of(obj) {
+    when "string":
+      return obj
+    when "int", "float", "bool":
+      return string(obj)
+    when "null":
+      return "null"
+    when "undefined":
+      return "undefined"
+    when "list":
+      output = "["
+      lastIndex = length(obj) - 1
+      for obj as index, value {
+        if index < lastIndex {
+          output += to_string(value) + ", "
+        } else {
+          output += to_string(value) + "]"
+        }
+      }
+      return output
+    when "map":
+      output = "{"
+      theKeys = keys(obj)
+      lastIndex = length(theKeys) - 1
+      for theKeys as index, key {
+        if index < lastIndex {
+          output += to_string(key) + ": " + to_string(obj[key]) + ", "
+        } else {
+          output += to_string(key) + ": " + to_string(obj[key]) + "}"
+        }
+      }
+      return output
+    else:
+      return ""
+  }
+}
+
+### evaluate_attribute ###
+# Evaluates the value of a resource's or block's attribute even if nested.
+# The resource should be derived by applying filters to tfplan.resource_changes.
+# It can be given in the initial call in the form rc.change.after or just rc
+# Indices of lists should be given as 0, 1, 2, and so on.
+# For example: boot_disk.0.initialize_params.0.image
+evaluate_attribute = func(r, attribute) {
+
+  # Split the attribute into a list, using "." as the separator
+  attributes = strings.split(attribute, ".")
+
+  # Convert numeric strings to integers for indices
+  if attributes[0] matches "^[0-9]+$" {
+    a = int(attributes[0])
+    # Make sure r is of type list
+    if types.type_of(r) is not "list" {
+      return undefined
+    }
+  } else {
+    a = attributes[0]
+  }
+
+  # Append the current attribute to the resource instance
+  if (types.type_of(r) is "map" and "change" in keys(r)) and
+     (types.type_of(r.change) is "map" and "after" in keys(r.change)) {
+    new_r = r.change.after[a] else null
+  } else {
+    new_r = r[a] else null
+  }
+
+  # Process based on length of attributes
+  # being greater than or equal to 1
+  if length(attributes) > 1 {
+
+    # Strip first element from attributes
+    attributes = attributes[1:length(attributes)]
+    attribute = strings.join(attributes, ".")
+
+    # Make recursive call
+    return evaluate_attribute(new_r, attribute)
+  } else {
+
+    # We reached the end of the attribute and can stop the
+    # recursive calls and return the value of the attribute
+    return new_r
+
+  }
+}
+
+### print_violations ###
+# Prints violations returned by any of the filter functions defined below.
+# This would normally only be called if the filter function had been called
+# with prtmsg set to false, which is sometimes done when processing resources
+# and their blocks.
+# If the result of a filter function is assigned to a map like violatingIRs,
+# then you should pass violatingIRs["message"] as the first argument.
+# The prefix argument is printed before the message of each resource.
+print_violations = func(messages, prefix) {
+  for messages as address, message {
+    print(prefix, message)
+  }
+  return true
+}
+
+### filter_attribute_not_in_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is not in a given list of allowed values (allowed).
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to allow null, include "null" in the list (allowed).
+filter_attribute_not_in_list = func(resources, attr, allowed, prtmsg) {
+  violators = {}
+  messages = {}
+  for resources as address, rc {
+    # Evaluate the value (v) of the attribute
+    v = evaluate_attribute(rc, attr) else null
+    # Convert null to "null"
+    if v is null {
+      v = "null"
+    }
+    # Check if the value is not in the allowed list
+    if v not in allowed {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that is not in the allowed list: " +
+                to_string(allowed)
+      violators[address] = rc
+      messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } // end if
+  } // end for
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_in_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is in a given list of forbidden values (forbidden).
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to disallow null, include "null" in the list (forbidden).
+filter_attribute_in_list = func(resources, attr, forbidden, prtmsg) {
+  violators = {}
+  messages = {}
+  for resources as address, rc {
+    # Evaluate the value (v) of the attribute
+    v = evaluate_attribute(rc, attr) else null
+    # Check if the value is null
+    if v is null {
+      v = "null"
+    }
+    # Check if the value is in the forbidden list
+    if v in forbidden {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that is in the forbidden list: " +
+                to_string(forbidden)
+      violators[address] = rc
+      messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_not_contains_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not contain a given list of required values (required).
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+filter_attribute_not_contains_list = func(resources, attr, required, prtmsg) {
+  violators = {}
+  messages = {}
+  for resources as address, rc {
+    # Evaluate the value (v) of the attribute
+    v = evaluate_attribute(rc, attr) else null
+    # Check if the value contains the desired allowed list
+    if v is null or
+       not (types.type_of(v) is "list" or types.type_of(v) is "map") {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is missing, null, or is not a map or a list"
+      violators[address] = rc
+      messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else {
+      missing_values = []
+      for required as rv {
+        if v not contains rv {
+          append(missing_values, rv)
+        } // end if
+      } // end for required
+      if length(missing_values) > 0 {
+        # Build warning message when v is a map
+        message = to_string(address) + " has " + to_string(attr) + " " +
+                  to_string(v) + " that is missing the required items " +
+                  to_string(missing_values) + " from the list: " +
+                  to_string(required)
+        # Add the resource and warning message to the violators list
+        violators[address] = rc
+        messages[address] = message
+        if prtmsg {
+          print(message)
+        }
+      } // end length(missing_values)
+    } // end else v not null
+  } // end for
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_contains_items_from_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that contains any items from a given list of
+# forbidden values (forbidden).
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to disallow null, include "null" in the list (forbidden).
+filter_attribute_contains_items_from_list = func(resources, attr, forbidden, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, rc {
+    # Evaluate the value (v) of the attribute
+    v = evaluate_attribute(rc, attr) else null
+    # Check if the value contains the desired allowed list
+    if not (types.type_of(v) is "list" or types.type_of(v) is "map" or
+            types.type_of(v) is "null") {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " " +
+                to_string(v) + " that is not a map, a list, or null"
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if v is null {
+      if "null" in forbidden {
+        # Add the resource and a warning message to the violators list
+        message = to_string(address) + " has " + to_string(attr) +
+                  " with value null from the forbidden list: " +
+                  to_string(forbidden)
+        violators[address] = rc
+				messages[address] = message
+        if prtmsg {
+          print(message)
+        }
+      }
+    } else {
+      forbidden_values = []
+      for forbidden as fv {
+        if v contains fv {
+          append(forbidden_values, fv)
+        } // end if
+      } // end for forbidden
+      if length(forbidden_values) > 0 {
+        # Build warning message when v is a list
+        message = to_string(address) + " has " + to_string(attr) + " " +
+                  to_string(v) + " that has items " + to_string(forbidden_values) +
+                  " from the forbidden list: " + to_string(forbidden)
+        # Add the resource and a warning message to the violators list
+        violators[address] = rc
+				messages[address] = message
+        if prtmsg {
+          print(message)
+        }
+      } // end length(forbidden_values)
+    } // end v not null
+  } // end for
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_contains_items_not_in_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that contains items not in a given list of allowed values.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to allow null, include "null" in the list (allowed).
+filter_attribute_contains_items_not_in_list = func(resources, attr, allowed, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, rc {
+    # Evaluate the value (vals) of the attribute
+    vals = evaluate_attribute(rc, attr) else null
+    # Check if the value contains items not in allowed list
+    if not (types.type_of(vals) is "list" or types.type_of(vals) is "map" or
+            types.type_of(vals) is "null") {
+        # Add the resource and a warning message to the violators list
+        message = to_string(address) + " has " + to_string(attr) + " " +
+                  to_string(vals) + " that is not a map, a list, or null"
+        violators[address] = rc
+        messages[address] = message
+        if prtmsg {
+          print(message)
+        }
+    } else if vals is null {
+      if "null" not in allowed {
+        # Add the resource and a warning message to the violators list
+        message = to_string(address) + " has " + to_string(attr) +
+                  " with value null " + "that is not in the allowed list: " +
+                  to_string(allowed)
+        violators[address] = rc
+        messages[address] = message
+        if prtmsg {
+          print(message)
+        }
+      }
+    } else {
+      forbidden_values = []
+      for vals as v {
+        if v not in allowed {
+          append(forbidden_values, v)
+        } // end if v not allowed
+      } // end for vals
+      if length(forbidden_values) > 0 {
+        # Build warning message when vals is a map
+        message = to_string(address) + " has " + to_string(attr) + " " +
+                  to_string(vals) + " with items " + to_string(forbidden_values) +
+                  " that are not in the allowed list: " + to_string(allowed)
+        # Add the resource and a warning message to the violators list
+        violators[address] = rc
+				messages[address] = message
+        if prtmsg {
+          print(message)
+        }
+      } // end length(forbidden_values)
+    } // end if null
+  } // end for
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_is_not_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not have a given value.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_is_not_value = func(resources, attr, value, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, rc {
+    v = evaluate_attribute(rc, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if v is not value {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that is not equal to " + to_string(value)
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_is_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that has a given value.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_is_value = func(resources, attr, value, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, rc {
+    v = evaluate_attribute(rc, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if v is value {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that is equal to " + to_string(value)
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_greater_than_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is greater than a given numeric value.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_greater_than_value = func(resources, attr, value, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, rc {
+    v = evaluate_attribute(rc, attr) else null
+    if float(v) else null is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if float(v) > value {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that is greater than " + to_string(value)
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_less_than_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is less than a given numeric value.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_less_than_value = func(resources, attr, value, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, rc {
+    v = evaluate_attribute(rc, attr) else null
+    if float(v) else null is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if float(v) < value {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that is less than " + to_string(value)
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_does_not_match_regex ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not match a regular expression (expr).
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_does_not_match_regex = func(resources, attr, expr, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, rc {
+    v = evaluate_attribute(rc, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if v not matches expr {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that does not match the regex " + to_string(expr)
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_matches_regex ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that matches a regular expression (expr).
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_matches_regex = func(resources, attr, expr, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, rc {
+    v = evaluate_attribute(rc, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if v matches expr {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that matches the regex " + to_string(expr)
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_does_not_have_prefix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not have a given prefix.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_does_not_have_prefix = func(resources, attr, prefix, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, rc {
+    v = evaluate_attribute(rc, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if not strings.has_prefix(v, prefix) {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that does not have the prefix " + to_string(prefix)
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_has_prefix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that has a given prefix.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_has_prefix = func(resources, attr, prefix, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, rc {
+    v = evaluate_attribute(rc, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if strings.has_prefix(v, prefix) {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that has the prefix " + to_string(prefix)
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_does_not_have_suffix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not have a given suffix.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_does_not_have_suffix = func(resources, attr, suffix, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, rc {
+    v = evaluate_attribute(rc, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if not strings.has_suffix(v, suffix) {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that does not have the suffix " + to_string(suffix)
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_has_suffix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that has a given suffix.
+# Resources should be derived by applying filters to tfplan.resource_changes.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_has_suffix = func(resources, attr, suffix, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, rc {
+    v = evaluate_attribute(rc, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if strings.has_suffix(v, suffix) {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that has the suffix " + to_string(suffix)
+      violators[address] = rc
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/common-functions/tfstate-functions/tfstate-functions.sentinel
+# Common functions that use the tfstate/v2 import
+
+# The filter functions all accept a collection of resources, an attribute,
+# a value or a list of values, and a boolean, prtmsg, which can be true or false
+# and indicates whether the filter function should print violation messages.
+# The filter functions return a map consisting of 2 items:
+#   * "resources": a map consisting of resources that violate a condition
+#   * "messages":  a map of violation messages associated with the resources
+# Note that both the resources and messages collections are indexed by the
+# address of the resources, so they will have the same order and length.
+# The filter functions all call evaluate_attribute() to evaluate attributes
+# of resources even if nested deep within them.
+
+##### Imports #####
+import "tfstate/v2" as tfstate
+import "strings"
+import "types"
+
+##### Functions #####
+
+### find_resources ###
+# Find all resources of a specific type using the tfstate/v2 import.
+find_resources = func(type) {
+  resources = filter tfstate.resources as address, r {
+  	r.type is type and
+  	r.mode is "managed"
+  }
+
+  return resources
+}
+
+### find_datasources ###
+# Find all data sources of a specific type using the tfstate/v2 import.
+find_datasources = func(type) {
+  datasources = filter tfstate.resources as address, d {
+  	d.type is type and
+  	d.mode is "data"
+  }
+
+  return datasources
+}
+
+### find_blocks ###
+# Find all blocks of a specific type from a resource using the tfstate/v2 import.
+# parent should be a single resource or block of a resource or a data source
+# or block of a data source.
+# child should be a string representing a block of parent
+# that contains a list of objects.
+find_blocks = func(parent, child) {
+  if types.type_of(parent[child] else null) is "list" {
+      return parent[child]
+  } else {
+      return []
+  }
+}
+
+### to_string ###
+# Convert objects of unknown type to string
+# It is used to build messages added to the messages map returned by the
+# filter functions
+to_string = func(obj) {
+  case types.type_of(obj) {
+    when "string":
+      return obj
+    when "int", "float", "bool":
+      return string(obj)
+    when "null":
+      return "null"
+    when "undefined":
+      return "undefined"
+    when "list":
+      output = "["
+      lastIndex = length(obj) - 1
+      for obj as index, value {
+        if index < lastIndex {
+          output += to_string(value) + ", "
+        } else {
+          output += to_string(value) + "]"
+        }
+      }
+      return output
+    when "map":
+      output = "{"
+      theKeys = keys(obj)
+      lastIndex = length(theKeys) - 1
+      for theKeys as index, key {
+        if index < lastIndex {
+          output += to_string(key) + ": " + to_string(obj[key]) + ", "
+        } else {
+          output += to_string(key) + ": " + to_string(obj[key]) + "}"
+        }
+      }
+      return output
+    else:
+      return ""
+  }
+}
+
+### evaluate_attribute ###
+# Evaluates the value of a resource's or block's attribute even if nested.
+# The resource should be given in the initial call in the form
+# "r.values" where r is a resource derived by
+# applying filters to tfstate.resources.
+# Indices of lists should be given as 0, 1, 2, and so on.
+# For example: boot_disk.0.initialize_params.0.image
+evaluate_attribute = func(r, attribute) {
+
+  # Split the attribute into a list, using "." as the separator
+  attributes = strings.split(attribute, ".")
+
+  # Convert numeric strings to integers for indices
+  if attributes[0] matches "^[0-9]+$" {
+    a = int(attributes[0])
+    # Make sure r is of type list
+    if types.type_of(r) is not "list" {
+      return undefined
+    }
+  } else {
+    a = attributes[0]
+  }
+
+  # Append the current attribute to the resource instance
+  new_r = r[a] else null
+
+  # Append the current attribute to the resource instance
+  # We check if r is a map having `values` (also a map) and `module_address`, so
+  # that filter functions can pass in `r` instead of `r.values`.
+  # The extra check for `module_address` is meant to make sure that `r`
+  # is really a resource from the tfstate/v2 resources collection rather than
+  # some block which just happens to have a key called `values`.
+  # An example of such a block is the `filters` block of the `aws_ami` data source.
+  if types.type_of(r) is "map" and
+     "values" in keys(r) and
+     types.type_of(r.values) is "map" and
+     "module_address" in keys(r) {
+    new_r = r.values[a] else null
+  } else {
+    new_r = r[a] else null
+  }
+
+  # Process based on length of attributes
+  # being greater than or equal to 1
+  if length(attributes) > 1 {
+
+    # Strip first element from attributes
+    attributes = attributes[1:length(attributes)]
+    attribute = strings.join(attributes, ".")
+
+    # Make recursive call
+    return evaluate_attribute(new_r, attribute)
+  } else {
+
+    # We reached the end of the attribute and can stop the
+    # recursive calls and return the value of the attribute
+    return new_r
+
+  }
+}
+
+### print_violations ###
+# Prints violations returned by any of the filter functions defined below.
+# This would normally only be called if the filter function had been called
+# with prtmsg set to false, which is sometimes done when processing resources
+# and their blocks.
+# If the result of a filter function is assigned to a map like violatingIRs,
+# then you should pass violatingIRs["message"] as the first argument.
+# The prefix argument is printed before the message of each resource.
+print_violations = func(messages, prefix) {
+  for messages as address, message {
+    print(prefix, message)
+  }
+  return true
+}
+
+### filter_attribute_not_in_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is not in a given list of allowed values (allowed).
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to allow null, include "null" in the list (allowed).
+filter_attribute_not_in_list = func(resources, attr, allowed, prtmsg) {
+  violators = {}
+  messages = {}
+  for resources as address, r {
+    # Evaluate the value (v) of the attribute
+    v = evaluate_attribute(r, attr) else null
+    # Convert null to "null"
+    if v is null {
+      v = "null"
+    }
+    # Check if the value is not in the allowed list
+    if v not in allowed {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that is not in the allowed list: " +
+                to_string(allowed)
+      violators[address] = r
+      messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } // end if
+  } // end for
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_in_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is in a given list of forbidden values (forbidden).
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to disallow null, include "null" in the list (forbidden).
+filter_attribute_in_list = func(resources, attr, forbidden, prtmsg) {
+  violators = {}
+  messages = {}
+  for resources as address, r {
+    # Evaluate the value (v) of the attribute
+    v = evaluate_attribute(r, attr) else null
+    # Check if the value is null
+    if v is null {
+      v = "null"
+    }
+    # Check if the value is in the forbidden list
+    if v in forbidden {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that is in the forbidden list: " +
+                to_string(forbidden)
+      violators[address] = r
+      messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_not_contains_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not contain a given list of required values (required).
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# Resources should be derived by applying filters to tfstate.resources.
+filter_attribute_not_contains_list = func(resources, attr, required, prtmsg) {
+  violators = {}
+  messages = {}
+  for resources as address, r {
+    # Evaluate the value (v) of the attribute
+    v = evaluate_attribute(r, attr) else null
+    # Check if the value contains the desired allowed list
+    if v is null or
+       not (types.type_of(v) is "list" or types.type_of(v) is "map") {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is missing, null, or is not a map or a list"
+      violators[address] = r
+      messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else {
+      missing_values = []
+      for required as rv {
+        if v not contains rv {
+          append(missing_values, rv)
+        } // end if
+      } // end for required
+      if length(missing_values) > 0 {
+        # Build warning message when v is a map
+        message = to_string(address) + " has " + to_string(attr) + " " +
+                  to_string(v) + " that is missing the required items " +
+                  to_string(missing_values) + " from the list: " +
+                  to_string(required)
+        # Add the resource and warning message to the violators list
+        violators[address] = r
+        messages[address] = message
+        if prtmsg {
+          print(message)
+        }
+      } // end length(missing_values)
+    } // end else v not null
+  } // end for
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_contains_items_from_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that contains any items from a given list of
+# forbidden values (forbidden).
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to disallow null, include "null" in the list (forbidden).
+filter_attribute_contains_items_from_list = func(resources, attr, forbidden, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, r {
+    # Evaluate the value (v) of the attribute
+    v = evaluate_attribute(r, attr) else null
+    # Check if the value contains the desired allowed list
+    if not (types.type_of(v) is "list" or types.type_of(v) is "map" or
+            types.type_of(v) is "null") {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " " +
+                to_string(v) + " that is not a map, a list, or null"
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if v is null {
+      if "null" in forbidden {
+        # Add the resource and a warning message to the violators list
+        message = to_string(address) + " has " + to_string(attr) +
+                  " with value null from the forbidden list: " +
+                  to_string(forbidden)
+        violators[address] = r
+				messages[address] = message
+        if prtmsg {
+          print(message)
+        }
+      }
+    } else {
+      forbidden_values = []
+      for forbidden as fv {
+        if v contains fv {
+          append(forbidden_values, fv)
+        } // end if
+      } // end for forbidden
+      if length(forbidden_values) > 0 {
+        # Build warning message when v is a list
+        message = to_string(address) + " has " + to_string(attr) + " " +
+                  to_string(v) + " that has items " + to_string(forbidden_values) +
+                  " from the forbidden list: " + to_string(forbidden)
+        # Add the resource and a warning message to the violators list
+        violators[address] = r
+				messages[address] = message
+        if prtmsg {
+          print(message)
+        }
+      } // end length(forbidden_values)
+    } // end v not null
+  } // end for
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_contains_items_not_in_list ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that contains items not in a given list of allowed values.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+# If you want to allow null, include "null" in the list (allowed).
+filter_attribute_contains_items_not_in_list = func(resources, attr, allowed, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, r {
+    # Evaluate the value (vals) of the attribute
+    vals = evaluate_attribute(r, attr) else null
+    # Check if the value contains items not in allowed list
+    if not (types.type_of(vals) is "list" or types.type_of(vals) is "map" or
+            types.type_of(vals) is "null") {
+        # Add the resource and a warning message to the violators list
+        message = to_string(address) + " has " + to_string(attr) + " " +
+                  to_string(vals) + " that is not a map, a list, or null"
+        violators[address] = r
+        messages[address] = message
+        if prtmsg {
+          print(message)
+        }
+    } else if vals is null {
+      if "null" not in allowed {
+        # Add the resource and a warning message to the violators list
+        message = to_string(address) + " has " + to_string(attr) +
+                  " with value null " + "that is not in the allowed list: " +
+                  to_string(allowed)
+        violators[address] = r
+        messages[address] = message
+        if prtmsg {
+          print(message)
+        }
+      }
+    } else {
+      forbidden_values = []
+      for vals as v {
+        if v not in allowed {
+          append(forbidden_values, v)
+        } // end if v not allowed
+      } // end for vals
+      if length(forbidden_values) > 0 {
+        # Build warning message when vals is a map
+        message = to_string(address) + " has " + to_string(attr) + " " +
+                  to_string(vals) + " with items " + to_string(forbidden_values) +
+                  " that are not in the allowed list: " + to_string(allowed)
+        # Add the resource and a warning message to the violators list
+        violators[address] = r
+				messages[address] = message
+        if prtmsg {
+          print(message)
+        }
+      } // end length(forbidden_values)
+    } // end if null
+  } // end for
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_is_not_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not have a given value.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_is_not_value = func(resources, attr, value, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, r {
+    v = evaluate_attribute(r, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if v is not value {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that is not equal to " + to_string(value)
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_is_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that has a given value.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_is_value = func(resources, attr, value, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, r {
+    v = evaluate_attribute(r, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if v is value {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that is equal to " + to_string(value)
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_greater_than_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is greater than a given numeric value.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_greater_than_value = func(resources, attr, value, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, r {
+    v = evaluate_attribute(r, attr) else null
+    if float(v) else null is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if float(v) > value {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that is greater than " + to_string(value)
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_less_than_value ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that is less than a given numeric value.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_less_than_value = func(resources, attr, value, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, r {
+    v = evaluate_attribute(r, attr) else null
+    if float(v) else null is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if float(v) < value {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that is less than " + to_string(value)
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_does_not_match_regex ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not match a regular expression (expr).
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_does_not_match_regex = func(resources, attr, expr, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, r {
+    v = evaluate_attribute(r, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if v not matches expr {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that does not match the regex " + to_string(expr)
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_matches_regex ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that matches a regular expression (expr).
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_matches_regex = func(resources, attr, expr, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, r {
+    v = evaluate_attribute(r, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if v matches expr {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that matches the regex " + to_string(expr)
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_does_not_have_prefix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not have a given prefix.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_does_not_have_prefix = func(resources, attr, prefix, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, r {
+    v = evaluate_attribute(r, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if not strings.has_prefix(v, prefix) {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that does not have the prefix " + to_string(prefix)
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_has_prefix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that has a given prefix.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_has_prefix = func(resources, attr, prefix, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, r {
+    v = evaluate_attribute(r, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if strings.has_prefix(v, prefix) {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that has the prefix " + to_string(prefix)
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_does_not_have_suffix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that does not have a given suffix.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_does_not_have_suffix = func(resources, attr, suffix, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, r {
+    v = evaluate_attribute(r, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if not strings.has_suffix(v, suffix) {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that does not have the suffix " + to_string(suffix)
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+### filter_attribute_has_suffix ###
+# Filter a list of resources to those with a specified
+# attribute (attr) that has a given suffix.
+# Resources should be derived by applying filters to tfstate.resources.
+# Set prtmsg to `true` (without quotes) if you want to print violation messages.
+filter_attribute_has_suffix = func(resources, attr, suffix, prtmsg) {
+  violators = {}
+	messages = {}
+  for resources as address, r {
+    v = evaluate_attribute(r, attr) else null
+    if v is null {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) +
+                " that is null or undefined"
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    } else if strings.has_suffix(v, suffix) {
+      # Add the resource and a warning message to the violators list
+      message = to_string(address) + " has " + to_string(attr) + " with value " +
+                to_string(v) + " that has the suffix " + to_string(suffix)
+      violators[address] = r
+			messages[address] = message
+      if prtmsg {
+        print(message)
+      }
+    }
+  }
+  return {"resources":violators,"messages":messages}
+}
+
+EOF
+
+# restrict-vault-auth-methods
+cat <<-'EOF' > /root/sentinel/restrict-vault-auth-methods.sentinel
+# This policy restricts which Vault auth methods can be created
+
+# Import the v2 tfplan import, but use the alias "tfplan"
+import "tfplan/v2" as tfplan
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Allowed Vault Auth Methods
+allowed_methods = [
+  "<method1>",
+  "<method2>",
+  "<method3>",
+  "<method4>",
+]
+
+# Get all Vault auth methods
+allVaultAuthMethods = plan.find_resources("<resource_type>")
+
+# Filter to Vault auth methods with violations
+# Prints warnings for all violations
+violatingVaultAuthMethods = plan.filter_attribute_not_in_list(allVaultAuthMethods,
+                            "<attribute>", <list>, true)
+
+# Count violations
+violations = length(violatingVaultAuthMethods["messages"])
+
+# Main rule
+main = rule {
+  violations is 0
+}
+EOF
+
+mkdir -p /root/sentinel/test/restrict-vault-auth-methods
+
+cat <<-'EOF' > /root/sentinel/test/restrict-vault-auth-methods/fail.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-vault-auth-methods/pass.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-vault-auth-methods/mock-tfplan-fail.sentinel
+terraform_version = "0.12.24"
+resource_changes = {
+  "vault_auth_backend.test[0]": {
+    "address": "vault_auth_backend.test[0]",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "description": null,
+        "local":       null,
+        "path":        "roger-k8s",
+        "type":        "kubernetes",
+      },
+      "after_unknown": {
+        "accessor":                  true,
+        "default_lease_ttl_seconds": true,
+        "id":                    true,
+        "listing_visibility":    true,
+        "max_lease_ttl_seconds": true,
+        "tune":                  true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          0,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "test",
+    "provider_name":  "vault",
+    "type":           "vault_auth_backend",
+  },
+  "vault_auth_backend.test[1]": {
+    "address": "vault_auth_backend.test[1]",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "description": null,
+        "local":       null,
+        "path":        "roger-gh",
+        "type":        "github",
+      },
+      "after_unknown": {
+        "accessor":                  true,
+        "default_lease_ttl_seconds": true,
+        "id":                    true,
+        "listing_visibility":    true,
+        "max_lease_ttl_seconds": true,
+        "tune":                  true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          1,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "test",
+    "provider_name":  "vault",
+    "type":           "vault_auth_backend",
+  },
+  "vault_auth_backend.test[2]": {
+    "address": "vault_auth_backend.test[2]",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "description": null,
+        "local":       null,
+        "path":        "roger-aws",
+        "type":        "aws",
+      },
+      "after_unknown": {
+        "accessor":                  true,
+        "default_lease_ttl_seconds": true,
+        "id":                    true,
+        "listing_visibility":    true,
+        "max_lease_ttl_seconds": true,
+        "tune":                  true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          2,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "test",
+    "provider_name":  "vault",
+    "type":           "vault_auth_backend",
+  },
+}
+output_changes = {}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-vault-auth-methods/mock-tfplan-pass.sentinel
+terraform_version = "0.12.24"
+resource_changes = {
+  "vault_auth_backend.test[0]": {
+    "address": "vault_auth_backend.test[0]",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "description": null,
+        "local":       null,
+        "path":        "roger-k8s",
+        "type":        "kubernetes",
+      },
+      "after_unknown": {
+        "accessor":                  true,
+        "default_lease_ttl_seconds": true,
+        "id":                    true,
+        "listing_visibility":    true,
+        "max_lease_ttl_seconds": true,
+        "tune":                  true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          0,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "test",
+    "provider_name":  "vault",
+    "type":           "vault_auth_backend",
+  },
+  "vault_auth_backend.test[1]": {
+    "address": "vault_auth_backend.test[1]",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "description": null,
+        "local":       null,
+        "path":        "roger-gh",
+        "type":        "github",
+      },
+      "after_unknown": {
+        "accessor":                  true,
+        "default_lease_ttl_seconds": true,
+        "id":                    true,
+        "listing_visibility":    true,
+        "max_lease_ttl_seconds": true,
+        "tune":                  true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          1,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "test",
+    "provider_name":  "vault",
+    "type":           "vault_auth_backend",
+  },
+  "vault_auth_backend.test[2]": {
+    "address": "vault_auth_backend.test[2]",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "description": null,
+        "local":       null,
+        "path":        "roger-azure",
+        "type":        "azure",
+      },
+      "after_unknown": {
+        "accessor":                  true,
+        "default_lease_ttl_seconds": true,
+        "id":                    true,
+        "listing_visibility":    true,
+        "max_lease_ttl_seconds": true,
+        "tune":                  true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          2,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "test",
+    "provider_name":  "vault",
+    "type":           "vault_auth_backend",
+  },
+}
+output_changes = {}
+EOF
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-1/solve-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-1/solve-sentinel
@@ -1,0 +1,21 @@
+#!/bin/bash -l
+
+# Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+cd /root/sentinel
+
+# Edit the the policy
+sed -i 's/<method1>/azure/g' restrict-vault-auth-methods.sentinel
+sed -i 's/<method2>/kubernetes/g' restrict-vault-auth-methods.sentinel
+sed -i 's/<method3>/github/g' restrict-vault-auth-methods.sentinel
+sed -i 's/<method4>/approle/g' restrict-vault-auth-methods.sentinel
+sed -i 's/<resource_type>/vault_auth_backend/g' restrict-vault-auth-methods.sentinel
+sed -i 's/<attribute>/type/g' restrict-vault-auth-methods.sentinel
+sed -i 's/<list>/allowed_methods/g' restrict-vault-auth-methods.sentinel
+
+# Test the policy
+sentinel test -run=vault -verbose
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-2a/check-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-2a/check-sentinel
@@ -1,0 +1,33 @@
+#!/bin/bash -l
+
+set -e
+
+# Run 'touch /tmp/skip-check' to disable this check
+if [ -f /tmp/skip-check ]; then
+  rm /tmp/skip-check
+  exit 0
+fi
+
+cd /root/sentinel
+
+grep -qL "<resource_type>" require-access-keys-use-pgp-a.sentinel && fail-message "You have not replaced '<resource_type>' in require-access-keys-use-pgp-a.sentinel yet."
+
+grep -q "aws_iam_access_key" require-access-keys-use-pgp-a.sentinel || fail-message "You have not replaced '<resource_type>' with 'aws_iam_access_key' in require-access-keys-use-pgp-a.sentinel yet."
+
+grep -qL "<attribute>" require-access-keys-use-pgp-a.sentinel && fail-message "You have not replaced '<attribute>' in require-access-keys-use-pgp-a.sentinel yet."
+
+grep -q "pgp_key" require-access-keys-use-pgp-a.sentinel || fail-message "You have not replaced '<attribute>' with 'pgp_key' in require-access-keys-use-pgp-a.sentinel yet."
+
+grep -qL "<condition>" require-access-keys-use-pgp-a.sentinel && fail-message "You have not replaced '<condition>' in require-access-keys-use-pgp-a.sentinel yet."
+
+grep -q "violations is 0" require-access-keys-use-pgp-a.sentinel || grep -q "violations == 0" require-access-keys-use-pgp-a.sentinel || fail-message "You have not replaced '<condition>' with 'violations is 0' or 'violations == 0' in require-access-keys-use-pgp-a.sentinel yet."
+
+grep -q "sentinel test -run=pgp-a.sentinel -verbose" /root/.bash_history || fail-message "You haven't tested require-access-keys-use-pgp-a.sentinel yet. Please run 'sentinel test -run=pgp-a.sentinel -verbose'"
+
+sentinel test -run=pgp-a.sentinel
+rc=$?
+if [ $rc -ne 0 ]; then
+    fail-message "Your policy require-access-keys-use-pgp-a.sentinel did not pass all 4 test cases. Please revise and test it again."
+fi
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-2a/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-2a/setup-sentinel
@@ -1,0 +1,243 @@
+#!/bin/bash -l
+
+set -e
+
+cat <<-'EOF' > /root/sentinel/require-access-keys-use-pgp-a.sentinel
+# This policy requires AWS IAM access keys to use PGP keys
+
+# Import the v2 tfplan import, but use the alias "tfplan"
+import "tfplan/v2" as tfplan
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Get all AWS IAM access keys
+allIAMAccessKeys = plan.find_resources("<resource_type>")
+
+# Filter to AWS IAM access keys with violations
+# The called function prints warnings for all violations
+violatingIAMAccessKeys = plan.filter_attribute_does_not_have_prefix(
+                         allIAMAccessKeys, "<attribute>", "keybase:", true)
+
+# Count violations
+violations = length(violatingIAMAccessKeys["messages"])
+
+# Main rule
+main = rule {
+  <condition>
+}
+EOF
+
+mkdir -p /root/sentinel/test/require-access-keys-use-pgp-a
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-a/fail-invalid-value.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-invalid-value.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-a/fail-missing-value.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-missing-value.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-a/fail-with-null.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-with-null.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-a/mock-tfplan-fail-invalid-value.sentinel
+terraform_version = "0.12.24"
+resource_changes = {
+  "aws_iam_access_key.roger": {
+    "address": "aws_iam_access_key.roger",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "pgp_key": "roger",
+        "user":    "roger",
+      },
+      "after_unknown": {
+        "encrypted_secret":     true,
+        "id":                   true,
+        "key_fingerprint":      true,
+        "secret":               true,
+        "ses_smtp_password":    true,
+        "ses_smtp_password_v4": true,
+        "status":               true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "roger",
+    "provider_name":  "aws",
+    "type":           "aws_iam_access_key",
+  },
+}
+output_changes = {}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-a/mock-tfplan-fail-missing-value.sentinel
+terraform_version = "0.12.3"
+resource_changes = {
+  "aws_iam_access_key.roger": {
+    "address": "aws_iam_access_key.roger",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "user":    "roger",
+      },
+      "after_unknown": {
+        "encrypted_secret":     true,
+        "id":                   true,
+        "key_fingerprint":      true,
+        "pgp_key":              true,
+        "secret":               true,
+        "ses_smtp_password":    true,
+        "ses_smtp_password_v4": true,
+        "status":               true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "roger",
+    "provider_name":  "aws",
+    "type":           "aws_iam_access_key",
+  },
+}
+output_changes = {}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-a/mock-tfplan-fail-with-null.sentinel
+terraform_version = "0.12.3"
+resource_changes = {
+  "aws_iam_access_key.roger": {
+    "address": "aws_iam_access_key.roger",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "pgp_key": null,
+        "user":    "roger",
+      },
+      "after_unknown": {
+        "encrypted_secret":     true,
+        "id":                   true,
+        "key_fingerprint":      true,
+        "secret":               true,
+        "ses_smtp_password":    true,
+        "ses_smtp_password_v4": true,
+        "status":               true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "roger",
+    "provider_name":  "aws",
+    "type":           "aws_iam_access_key",
+  },
+}
+output_changes = {}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-a/mock-tfplan-pass.sentinel
+terraform_version = "0.12.24"
+resource_changes = {
+  "aws_iam_access_key.roger": {
+    "address": "aws_iam_access_key.roger",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "pgp_key": "keybase:roger",
+        "user":    "roger",
+      },
+      "after_unknown": {
+        "encrypted_secret":     true,
+        "id":                   true,
+        "key_fingerprint":      true,
+        "secret":               true,
+        "ses_smtp_password":    true,
+        "ses_smtp_password_v4": true,
+        "status":               true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "roger",
+    "provider_name":  "aws",
+    "type":           "aws_iam_access_key",
+  },
+}
+
+output_changes = {}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-a/pass.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}
+EOF
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-2a/solve-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-2a/solve-sentinel
@@ -1,0 +1,17 @@
+#!/bin/bash -l
+
+# Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+cd /root/sentinel
+
+# Edit the first version of the policy
+sed -i 's/<resource_type>/aws_iam_access_key/g' require-access-keys-use-pgp-a.sentinel
+sed -i 's/<attribute>/pgp_key/g' require-access-keys-use-pgp-a.sentinel
+sed -i 's/<condition>/violations is 0/g' require-access-keys-use-pgp-a.sentinel
+
+# Test the first version of the policy
+sentinel test -run=pgp-a.sentinel -verbose
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-2b/check-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-2b/check-sentinel
@@ -1,0 +1,31 @@
+#!/bin/bash -l
+
+set -e
+
+# Run 'touch /tmp/skip-check' to disable this check
+if [ -f /tmp/skip-check ]; then
+  rm /tmp/skip-check
+  exit 0
+fi
+
+cd /root/sentinel
+
+grep -qL "<expression>" require-access-keys-use-pgp-b.sentinel && fail-message "You have not replaced '<expression>' in require-access-keys-use-pgp-b.sentinel yet."
+
+grep -q "key.change.after.pgp_key else null" require-access-keys-use-pgp-b.sentinel || fail-message "You have not replaced '<expression>' with 'else null' in require-access-keys-use-pgp-b.sentinel yet."
+
+grep -qL "<condition_1>" require-access-keys-use-pgp-a.sentinel && fail-message "You have not replaced '<condition_1>' in require-access-keys-use-pgp-b.sentinel yet."
+
+grep -q "pgp_key is null" require-access-keys-use-pgp-b.sentinel || grep -q "pgp_key == null" require-access-keys-use-pgp-b.sentinel || fail-message "You have not replaced '<condition_1>' with 'pgp_key is null' or 'pgp_key == null' in require-access-keys-use-pgp-b.sentinel yet."
+
+grep -qL "<condition_2>" require-access-keys-use-pgp-a.sentinel && fail-message "You have not replaced '<condition_2>' in require-access-keys-use-pgp-b.sentinel yet."
+
+grep -q 'not strings.has_prefix(.*pgp_key.*,.*"keybase:")' require-access-keys-use-pgp-b.sentinel || fail-message "You have not replaced '<condition_2>' with 'not strings.has_prefix(pgp_key, \"keybase:\")' in require-access-keys-use-pgp-b.sentinel yet."
+
+sentinel test -run=pgp-b.sentinel
+rc=$?
+if [ $rc -ne 0 ]; then
+    fail-message "Your policy require-access-keys-use-pgp-b.sentinel did not pass all 4 test cases. Please revise and test it again."
+fi
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-2b/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-2b/setup-sentinel
@@ -1,0 +1,260 @@
+#!/bin/bash -l
+
+set -e
+
+cat <<-'EOF' > /root/sentinel/require-access-keys-use-pgp-b.sentinel
+# This policy requires AWS IAM access keys to use PGP keys
+
+# Import the v2 tfplan import, but use the alias "tfplan"
+import "tfplan/v2" as tfplan
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Standard strings import
+import "strings"
+
+# Get all AWS IAM access keys
+allIAMAccessKeys = plan.find_resources("aws_iam_access_key")
+
+# Filter to AWS IAM access keys with violations
+violatingIAMAccessKeys = {}
+for allIAMAccessKeys as address, key {
+  # Set the pgp_key variable, but set to null if undefined
+  pgp_key = key.change.after.pgp_key <expression>
+  # First, check if pgp_key is missing
+  # Second, check if pgp_key does not start with "keybase:"
+  # Add violators to violatingIAMAccessKeys and print warnings
+  if <condition_1> {
+    violatingIAMAccessKeys[address] = key
+    print(address, "does not have the pgp_key attribute set")
+  } else if <condition_2> {
+    violatingIAMAccessKeys[address] = key
+    print(address, "has attribute pgp_key with value", pgp_key,
+          "that does not start with 'keybase:'")
+  }
+}
+
+# Count violations
+violations = length(violatingIAMAccessKeys)
+
+# Main rule
+main = rule {
+  violations is 0
+}
+
+EOF
+
+mkdir -p /root/sentinel/test/require-access-keys-use-pgp-b
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-b/fail-invalid-value.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-invalid-value.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-b/fail-missing-value.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-missing-value.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-b/fail-with-null.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-with-null.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-b/mock-tfplan-fail-invalid-value.sentinel
+terraform_version = "0.12.24"
+resource_changes = {
+  "aws_iam_access_key.roger": {
+    "address": "aws_iam_access_key.roger",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "pgp_key": "roger",
+        "user":    "roger",
+      },
+      "after_unknown": {
+        "encrypted_secret":     true,
+        "id":                   true,
+        "key_fingerprint":      true,
+        "secret":               true,
+        "ses_smtp_password":    true,
+        "ses_smtp_password_v4": true,
+        "status":               true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "roger",
+    "provider_name":  "aws",
+    "type":           "aws_iam_access_key",
+  },
+}
+output_changes = {}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-b/mock-tfplan-fail-missing-value.sentinel
+terraform_version = "0.12.3"
+resource_changes = {
+  "aws_iam_access_key.roger": {
+    "address": "aws_iam_access_key.roger",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "user":    "roger",
+      },
+      "after_unknown": {
+        "encrypted_secret":     true,
+        "id":                   true,
+        "key_fingerprint":      true,
+        "pgp_key":              true,
+        "secret":               true,
+        "ses_smtp_password":    true,
+        "ses_smtp_password_v4": true,
+        "status":               true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "roger",
+    "provider_name":  "aws",
+    "type":           "aws_iam_access_key",
+  },
+}
+output_changes = {}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-b/mock-tfplan-fail-with-null.sentinel
+terraform_version = "0.12.3"
+resource_changes = {
+  "aws_iam_access_key.roger": {
+    "address": "aws_iam_access_key.roger",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "pgp_key": null,
+        "user":    "roger",
+      },
+      "after_unknown": {
+        "encrypted_secret":     true,
+        "id":                   true,
+        "key_fingerprint":      true,
+        "secret":               true,
+        "ses_smtp_password":    true,
+        "ses_smtp_password_v4": true,
+        "status":               true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "roger",
+    "provider_name":  "aws",
+    "type":           "aws_iam_access_key",
+  },
+}
+output_changes = {}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-b/mock-tfplan-pass.sentinel
+terraform_version = "0.12.24"
+resource_changes = {
+  "aws_iam_access_key.roger": {
+    "address": "aws_iam_access_key.roger",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "pgp_key": "keybase:roger",
+        "user":    "roger",
+      },
+      "after_unknown": {
+        "encrypted_secret":     true,
+        "id":                   true,
+        "key_fingerprint":      true,
+        "secret":               true,
+        "ses_smtp_password":    true,
+        "ses_smtp_password_v4": true,
+        "status":               true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "roger",
+    "provider_name":  "aws",
+    "type":           "aws_iam_access_key",
+  },
+}
+
+output_changes = {}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-access-keys-use-pgp-b/pass.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}
+EOF
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-2b/solve-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-2b/solve-sentinel
@@ -1,0 +1,17 @@
+#!/bin/bash -l
+
+# Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+cd /root/sentinel
+
+# Edit the second version of the policy
+sed -i 's/<expression>/else null/g' require-access-keys-use-pgp-b.sentinel
+sed -i 's/<condition_1>/pgp_key is null/g' require-access-keys-use-pgp-b.sentinel
+sed -i 's/<condition_2>/not strings.has_prefix(pgp_key, "keybase:")/g' require-access-keys-use-pgp-b.sentinel
+
+# Test the second version of the policy
+sentinel test -run=pgp-b.sentinel -verbose
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-3a/check-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-3a/check-sentinel
@@ -1,0 +1,36 @@
+#!/bin/bash -l
+
+set -e
+
+# Run 'touch /tmp/skip-check' to disable this check
+if [ -f /tmp/skip-check ]; then
+  rm /tmp/skip-check
+  exit 0
+fi
+
+cd /root/sentinel
+
+grep -qL "<data_source_type>" restrict-acm-certificate-domains-a.sentinel && fail-message "You have not replaced '<data_source_type>' in restrict-acm-certificate-domains-a.sentinel yet."
+
+grep -q "aws_acm_certificate" restrict-acm-certificate-domains-a.sentinel || fail-message "You have not replaced '<data_source_type>' with 'aws_acm_certificate' in restrict-acm-certificate-domains-a.sentinel yet."
+
+grep -qL "<attribute>" restrict-acm-certificate-domains-a.sentinel && fail-message "You have not replaced '<attribute>' in restrict-acm-certificate-domains-a.sentinel yet."
+
+grep -q "cert.values.domain" restrict-acm-certificate-domains-a.sentinel || fail-message "You have not replaced '<attribute>' with 'cert.values.domain' in restrict-acm-certificate-domains-a.sentinel yet."
+
+grep -qL "<expression>" restrict-acm-certificate-domains-a.sentinel && fail-message "You have not replaced '<expression>' in restrict-acm-certificate-domains-a.sentinel yet."
+
+matches=$(grep "cert.values.domain" restrict-acm-certificate-domains-a.sentinel | wc -l)
+if [ $matches -ne 2 ]; then
+    fail-message "You have not replaced '<expression>' with 'cert.values.domain' in restrict-acm-certificate-domains-a.sentinel yet."
+fi
+
+grep -q "sentinel test -run=domains-a.sentinel -verbose" /root/.bash_history || grep -q "sentinel test -run=domains-a.sentinel" /root/.bash_history || fail-message "You haven't tested the restrict-acm-certificate-domains-a.sentinel policy against the test cases yet. Please run 'sentinel test -run=domains-a.sentinel -verbose'"
+
+sentinel test -run=domains-a.sentinel
+rc=$?
+if [ $rc -ne 0 ]; then
+    fail-message "Your policy restrict-acm-certificate-domains-a.sentinel did not pass both test cases. Please revise and test it again."
+fi
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-3a/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-3a/setup-sentinel
@@ -1,0 +1,167 @@
+#!/bin/bash -l
+
+set -e
+
+cat <<-'EOF' > /root/sentinel/restrict-acm-certificate-domains-a.sentinel
+# This policy uses the tfstate import to restrict ACM certificates
+# to have domains that are sub-domains of hashidemos.io
+
+# Import the v2 tfstate import, but use the alias "tfstate"
+import "tfstate/v2" as tfstate
+
+# Import common-functions/tfstate-functions/tfstate-functions.sentinel
+# with alias "state"
+import "tfstate-functions" as state
+
+# Get all AWS ACM certs
+allACMCerts = state.find_datasources("<data_source_type>")
+
+# Filter to ACM certs that are not sub-domains of hashidemos.io
+violatingACMCerts = filter allACMCerts as address, cert {
+  cert.values.<attribute> else "" not matches "(.+)\\.hashidemos\\.io$" and
+  print(address, "has domain", <expression>,
+        "that is not a sub-domain of hashidemos.io")
+}
+
+# Count violations
+violations = length(violatingACMCerts)
+
+# Main rule that evaluates the result of the validation function
+main = rule {
+  violations is 0
+}
+EOF
+
+mkdir -p /root/sentinel/test/restrict-acm-certificate-domains-a
+
+cat <<-'EOF' > /root/sentinel/test/restrict-acm-certificate-domains-a/fail.json
+{
+  "modules": {
+    "tfstate-functions": {
+      "path": "../../common-functions/tfstate-functions/tfstate-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfstate/v2": "mock-tfstate-fail.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-acm-certificate-domains-a/pass.json
+{
+  "modules": {
+    "tfstate-functions": {
+      "path": "../../common-functions/tfstate-functions/tfstate-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfstate/v2": "mock-tfstate-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-acm-certificate-domains-a/mock-tfstate-fail.sentinel
+terraform_version = "0.12.3"
+outputs = {}
+resources = {
+  "aws_acm_certificate.cert_1": {
+    "address":        "aws_acm_certificate.cert_1",
+    "depends_on":     [],
+    "deposed_key":    "",
+    "index":          null,
+    "mode":           "data",
+    "module_address": "",
+    "name":           "cert_1",
+    "provider_name":  "aws",
+    "tainted":        false,
+    "type":           "aws_acm_certificate",
+    "values": {
+      "arn":         "arn:aws:acm:us-east-1:753646501470:certificate/1f485f70-2bc1-4ae3-a30f-a533605e99b9",
+      "domain":      "cam-vault.hashydemos.io",
+      "id":          "2020-03-25 16:37:53.939547607 +0000 UTC",
+      "key_types":   null,
+      "most_recent": false,
+      "statuses":    null,
+      "types":       null,
+    },
+  },
+  "aws_acm_certificate.cert_2": {
+    "address":        "aws_acm_certificate.cert_2",
+    "depends_on":     [],
+    "deposed_key":    "",
+    "index":          null,
+    "mode":           "data",
+    "module_address": "",
+    "name":           "cert_2",
+    "provider_name":  "aws",
+    "tainted":        false,
+    "type":           "aws_acm_certificate",
+    "values": {
+      "arn":         "arn:aws:acm:us-east-1:753646501470:certificate/5c9b4d26-b955-4c55-a895-ee7c87020526",
+      "domain":      "roger-ptfe.hashydemos.io",
+      "id":          "2020-03-25 16:37:53.938086355 +0000 UTC",
+      "key_types":   null,
+      "most_recent": false,
+      "statuses":    null,
+      "types":       null,
+    },
+  },
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-acm-certificate-domains-a/mock-tfstate-pass.sentinel
+terraform_version = "0.12.3"
+outputs = {}
+resources = {
+  "aws_acm_certificate.cert_1": {
+    "address":        "aws_acm_certificate.cert_1",
+    "depends_on":     [],
+    "deposed_key":    "",
+    "index":          null,
+    "mode":           "data",
+    "module_address": "",
+    "name":           "cert_1",
+    "provider_name":  "aws",
+    "tainted":        false,
+    "type":           "aws_acm_certificate",
+    "values": {
+      "arn":         "arn:aws:acm:us-east-1:753646501470:certificate/1f485f70-2bc1-4ae3-a30f-a533605e99b9",
+      "domain":      "cam-vault.hashidemos.io",
+      "id":          "2020-03-25 16:37:53.939547607 +0000 UTC",
+      "key_types":   null,
+      "most_recent": false,
+      "statuses":    null,
+      "types":       null,
+    },
+  },
+  "aws_acm_certificate.cert_2": {
+    "address":        "aws_acm_certificate.cert_2",
+    "depends_on":     [],
+    "deposed_key":    "",
+    "index":          null,
+    "mode":           "data",
+    "module_address": "",
+    "name":           "cert_2",
+    "provider_name":  "aws",
+    "tainted":        false,
+    "type":           "aws_acm_certificate",
+    "values": {
+      "arn":         "arn:aws:acm:us-east-1:753646501470:certificate/5c9b4d26-b955-4c55-a895-ee7c87020526",
+      "domain":      "roger-ptfe.hashidemos.io",
+      "id":          "2020-03-25 16:37:53.938086355 +0000 UTC",
+      "key_types":   null,
+      "most_recent": false,
+      "statuses":    null,
+      "types":       null,
+    },
+  },
+}
+EOF
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-3a/solve-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-3a/solve-sentinel
@@ -1,0 +1,17 @@
+#!/bin/bash -l
+
+# Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+cd /root/sentinel
+
+# Edit the first version of the policy
+sed -i 's/<data_source_type>/aws_acm_certificate/g' restrict-acm-certificate-domains-a.sentinel
+sed -i 's/<attribute>/domain/g' restrict-acm-certificate-domains-a.sentinel
+sed -i 's/<expression>/cert.values.domain/g' restrict-acm-certificate-domains-a.sentinel
+
+# Test the first version of the policy
+sentinel test -run=domains-a.sentinel -verbose
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-3b/check-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-3b/check-sentinel
@@ -1,0 +1,31 @@
+#!/bin/bash -l
+
+set -e
+
+# Run 'touch /tmp/skip-check' to disable this check
+if [ -f /tmp/skip-check ]; then
+  rm /tmp/skip-check
+  exit 0
+fi
+
+cd /root/sentinel
+
+grep -qL "<expression>" restrict-acm-certificate-domains-b.sentinel && fail-message "You have not replaced '<expression>' in restrict-acm-certificate-domains-b.sentinel yet."
+
+grep -q "cert.values.domain" restrict-acm-certificate-domains-b.sentinel || fail-message "You have not replaced '<expression>' with 'cert.values.domain' in restrict-acm-certificate-domains-b.sentinel yet."
+
+grep -qL "<condition>" restrict-acm-certificate-domains-b.sentinel && fail-message "You have not replaced '<condition>' in restrict-acm-certificate-domains-b.sentinel yet."
+
+grep -q "domain matches parent_domain" restrict-acm-certificate-domains-b.sentinel || fail-message "You have not replaced '<condition>' with 'domain matches parent_domain' in restrict-acm-certificate-domains-b.sentinel yet."
+
+grep -qL "<regex>" restrict-acm-certificate-domains-b.sentinel && fail-message "You have not replaced '<regex>' in restrict-acm-certificate-domains-b.sentinel yet."
+
+fgrep -q '(.+)\\.hashidemos\\.io$' restrict-acm-certificate-domains-b.sentinel || fail-message "You have not replaced '<regex>' with '(.+)\\\\\.hashidemos\\\\\.io$' in restrict-acm-certificate-domains-b.sentinel yet."
+
+sentinel test -run=domains-b.sentinel
+rc=$?
+if [ $rc -ne 0 ]; then
+    fail-message "Your policy restrict-acm-certificate-domains-b.sentinel did not pass both test cases. Please revise and test it again."
+fi
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-3b/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-3b/setup-sentinel
@@ -1,0 +1,186 @@
+#!/bin/bash -l
+
+set -e
+
+cat <<-'EOF' > /root/sentinel/restrict-acm-certificate-domains-b.sentinel
+# This policy uses the tfstate import to restrict ACM certificates
+# to have domains that are sub-domains of hashidemos.io
+
+# Import the v2 tfstate import, but use the alias "tfstate"
+import "tfstate/v2" as tfstate
+
+# Import common-functions/tfstate-functions/tfstate-functions.sentinel
+# with alias "state"
+import "tfstate-functions" as state
+
+# Get all AWS ACM certs
+allACMCerts = state.find_datasources("aws_acm_certificate")
+
+# Function that validates ACM certs
+validate_certs = func(certs, parent_domain) {
+
+  validated = true
+
+  # Loop through the data source instances
+  for certs as address, cert {
+    # Validate that the domain is sub-domain of parent_domain
+    # Use the matches operator
+    domain = <expression>
+    # Check if domain is sub-domain of parent domain, using the matches operator
+    if <condition> {
+      print(address, "has domain", domain,
+            "that matches the regex", parent_domain)
+    } else {
+      print(address, "has domain", domain,
+            "that does not match the regex", parent_domain, "or is missing")
+      validated = false
+    }
+  }
+
+  return validated
+
+}
+
+# Call the validation function
+# Pass it a list of ACM certs and a regex to match
+certs_validated = validate_certs(allACMCerts, "<regex>")
+
+# Main rule that evaluates the result of the validation function
+main = rule {
+  certs_validated
+}
+EOF
+
+mkdir -p /root/sentinel/test/restrict-acm-certificate-domains-b
+
+cat <<-'EOF' > /root/sentinel/test/restrict-acm-certificate-domains-b/fail.json
+{
+  "modules": {
+    "tfstate-functions": {
+      "path": "../../common-functions/tfstate-functions/tfstate-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfstate/v2": "mock-tfstate-fail.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-acm-certificate-domains-b/pass.json
+{
+  "modules": {
+    "tfstate-functions": {
+      "path": "../../common-functions/tfstate-functions/tfstate-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfstate/v2": "mock-tfstate-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-acm-certificate-domains-b/mock-tfstate-fail.sentinel
+terraform_version = "0.12.3"
+outputs = {}
+resources = {
+  "aws_acm_certificate.cert_1": {
+    "address":        "aws_acm_certificate.cert_1",
+    "depends_on":     [],
+    "deposed_key":    "",
+    "index":          null,
+    "mode":           "data",
+    "module_address": "",
+    "name":           "cert_1",
+    "provider_name":  "aws",
+    "tainted":        false,
+    "type":           "aws_acm_certificate",
+    "values": {
+      "arn":         "arn:aws:acm:us-east-1:753646501470:certificate/1f485f70-2bc1-4ae3-a30f-a533605e99b9",
+      "domain":      "cam-vault.hashydemos.io",
+      "id":          "2020-03-25 16:37:53.939547607 +0000 UTC",
+      "key_types":   null,
+      "most_recent": false,
+      "statuses":    null,
+      "types":       null,
+    },
+  },
+  "aws_acm_certificate.cert_2": {
+    "address":        "aws_acm_certificate.cert_2",
+    "depends_on":     [],
+    "deposed_key":    "",
+    "index":          null,
+    "mode":           "data",
+    "module_address": "",
+    "name":           "cert_2",
+    "provider_name":  "aws",
+    "tainted":        false,
+    "type":           "aws_acm_certificate",
+    "values": {
+      "arn":         "arn:aws:acm:us-east-1:753646501470:certificate/5c9b4d26-b955-4c55-a895-ee7c87020526",
+      "domain":      "roger-ptfe.hashydemos.io",
+      "id":          "2020-03-25 16:37:53.938086355 +0000 UTC",
+      "key_types":   null,
+      "most_recent": false,
+      "statuses":    null,
+      "types":       null,
+    },
+  },
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-acm-certificate-domains-b/mock-tfstate-pass.sentinel
+terraform_version = "0.12.3"
+outputs = {}
+resources = {
+  "aws_acm_certificate.cert_1": {
+    "address":        "aws_acm_certificate.cert_1",
+    "depends_on":     [],
+    "deposed_key":    "",
+    "index":          null,
+    "mode":           "data",
+    "module_address": "",
+    "name":           "cert_1",
+    "provider_name":  "aws",
+    "tainted":        false,
+    "type":           "aws_acm_certificate",
+    "values": {
+      "arn":         "arn:aws:acm:us-east-1:753646501470:certificate/1f485f70-2bc1-4ae3-a30f-a533605e99b9",
+      "domain":      "cam-vault.hashidemos.io",
+      "id":          "2020-03-25 16:37:53.939547607 +0000 UTC",
+      "key_types":   null,
+      "most_recent": false,
+      "statuses":    null,
+      "types":       null,
+    },
+  },
+  "aws_acm_certificate.cert_2": {
+    "address":        "aws_acm_certificate.cert_2",
+    "depends_on":     [],
+    "deposed_key":    "",
+    "index":          null,
+    "mode":           "data",
+    "module_address": "",
+    "name":           "cert_2",
+    "provider_name":  "aws",
+    "tainted":        false,
+    "type":           "aws_acm_certificate",
+    "values": {
+      "arn":         "arn:aws:acm:us-east-1:753646501470:certificate/5c9b4d26-b955-4c55-a895-ee7c87020526",
+      "domain":      "roger-ptfe.hashidemos.io",
+      "id":          "2020-03-25 16:37:53.938086355 +0000 UTC",
+      "key_types":   null,
+      "most_recent": false,
+      "statuses":    null,
+      "types":       null,
+    },
+  },
+}
+EOF
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-3b/solve-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-3b/solve-sentinel
@@ -1,0 +1,17 @@
+#!/bin/bash -l
+
+# Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+cd /root/sentinel
+
+# Edit the second version of the policy
+sed -i 's/<expression>/cert.values.domain/g' restrict-acm-certificate-domains-b.sentinel
+sed -i 's/<condition>/domain matches parent_domain/g' restrict-acm-certificate-domains-b.sentinel
+sed -i 's/<regex>/(.+)\\\\.hashidemos\\\\.io$/g' restrict-acm-certificate-domains-b.sentinel
+
+# Test the second version of the policy
+sentinel test -run=domains-b.sentinel -verbose
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-4a/check-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-4a/check-sentinel
@@ -1,0 +1,33 @@
+#!/bin/bash -l
+
+set -e
+
+# Run 'touch /tmp/skip-check' to disable this check
+if [ -f /tmp/skip-check ]; then
+  rm /tmp/skip-check
+  exit 0
+fi
+
+cd /root/sentinel
+
+grep -qL "<resource_type>" restrict-gcp-instance-image-a.sentinel && fail-message "You have not replaced '<resource_type>' in restrict-gcp-instance-image-a.sentinel yet."
+
+grep -q "google_compute_instance" restrict-gcp-instance-image-a.sentinel || fail-message "You have not replaced '<resource_type>' with 'google_compute_instance' in restrict-gcp-instance-image-a.sentinel yet."
+
+grep -qL "<expression_1>" restrict-gcp-instance-image-a.sentinel && fail-message "You have not replaced '<expression_1>' in restrict-gcp-instance-image-a.sentinel yet."
+
+fgrep -q "boot_disk.0.initialize_params.0.image" restrict-gcp-instance-image-a.sentinel || fail-message "You have not replaced '<expression_1>' with 'boot_disk.0.initialize_params.0.image' in restrict-gcp-instance-image-a.sentinel yet."
+
+grep -qL "<expression_2>" restrict-gcp-instance-image-a.sentinel && fail-message "You have not replaced '<expression_2>' in restrict-gcp-instance-image-a.sentinel yet."
+
+fgrep -q 'length(violatingGCPComputeInstances["messages"])' restrict-gcp-instance-image-a.sentinel || fail-message "You have not replaced '<expression_2>' with 'length(violatingGCPComputeInstances[\"messages\"]' in restrict-gcp-instance-image-a.sentinel yet."
+
+grep -q "sentinel test -run=image-a.sentinel -verbose" /root/.bash_history || grep -q "sentinel test -run=image-a.sentinel" /root/.bash_history || fail-message "You haven't tested the restrict-gcp-instance-image-a.sentinel policy against the test cases yet. Please run 'sentinel test -run=image-a.sentinel -verbose'"
+
+sentinel test -run=image-a.sentinel
+rc=$?
+if [ $rc -ne 0 ]; then
+    fail-message "Your policy restrict-gcp-instance-image-a.sentinel did not pass both test cases. Please revise and test it again."
+fi
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-4a/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-4a/setup-sentinel
@@ -1,0 +1,519 @@
+#!/bin/bash -l
+
+set -e
+
+cat <<-'EOF' > /root/sentinel/restrict-gcp-instance-image-a.sentinel
+# This policy restricts the public images that GCP compute instances use
+
+# Import the v2 tfplan import, but use the alias "tfplan"
+import "tfplan/v2" as tfplan
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Get all GCP compute instances
+allGCPComputeInstances = plan.find_resources("<resource_type>")
+
+# Filter to GCP compute instances with violations
+# Prints warnings for all violations
+violatingGCPComputeInstances =
+  plan.filter_attribute_is_not_value(allGCPComputeInstances,
+  "<expression_1>", "debian-cloud/debian-9", true)
+
+# Count violations
+violations = <expression_2>
+
+# Main rule
+main = rule {
+  violations is 0
+}
+EOF
+
+mkdir -p /root/sentinel/test/restrict-gcp-instance-image-a
+
+cat <<-'EOF' > /root/sentinel/test/restrict-gcp-instance-image-a/fail-no-initialize-params.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-no-initialize-params.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-gcp-instance-image-a/fail-invalid-image.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-invalid-image.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-gcp-instance-image-a/mock-tfplan-fail-no-initialize-params.sentinel
+terraform_version = "0.12.24"
+resource_changes = {
+  "google_compute_disk.default": {
+    "address": "google_compute_disk.default",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "description":         null,
+        "disk_encryption_key": [],
+        "image":               "debian-cloud/debian-9",
+        "labels": {
+          "environment": "dev",
+        },
+        "name": "test-disk",
+        "physical_block_size_bytes":      4096,
+        "snapshot":                       null,
+        "source_image_encryption_key":    [],
+        "source_snapshot_encryption_key": [],
+        "timeouts":                       null,
+        "type":                           "pd-ssd",
+        "zone":                           "us-east1-b",
+      },
+      "after_unknown": {
+        "creation_timestamp":  true,
+        "disk_encryption_key": [],
+        "id":                    true,
+        "label_fingerprint":     true,
+        "labels":                {},
+        "last_attach_timestamp": true,
+        "last_detach_timestamp": true,
+        "project":               true,
+        "self_link":             true,
+        "size":                  true,
+        "source_image_encryption_key":    [],
+        "source_image_id":                true,
+        "source_snapshot_encryption_key": [],
+        "source_snapshot_id":             true,
+        "users":                          true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "default",
+    "provider_name":  "google",
+    "type":           "google_compute_disk",
+  },
+  "google_compute_instance.demo_1": {
+    "address": "google_compute_instance.demo_1",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "allow_stopping_for_update": true,
+        "attached_disk":             [],
+        "boot_disk": [
+          {
+            "auto_delete":             true,
+            "disk_encryption_key_raw": null,
+            "mode": "READ_WRITE",
+          },
+        ],
+        "can_ip_forward":          false,
+        "deletion_protection":     false,
+        "description":             null,
+        "desired_status":          null,
+        "enable_display":          null,
+        "hostname":                null,
+        "labels":                  null,
+        "machine_type":            "n1-standard-1",
+        "metadata":                null,
+        "metadata_startup_script": null,
+        "name": "demo-1",
+        "network_interface": [
+          {
+            "access_config": [
+              {
+                "public_ptr_domain_name": null,
+              },
+            ],
+            "alias_ip_range": [],
+            "network":        "default",
+          },
+        ],
+        "scratch_disk": [],
+        "service_account": [
+          {
+            "scopes": [
+              "https://www.googleapis.com/auth/compute.readonly",
+              "https://www.googleapis.com/auth/monitoring",
+              "https://www.googleapis.com/auth/servicecontrol",
+            ],
+          },
+        ],
+        "shielded_instance_config": [],
+        "tags":     null,
+        "timeouts": null,
+        "zone":     "us-east1-b",
+      },
+      "after_unknown": {
+        "attached_disk": [],
+        "boot_disk": [
+          {
+            "device_name":                true,
+            "disk_encryption_key_sha256": true,
+            "initialize_params":          true,
+            "kms_key_self_link":          true,
+            "source":                     true,
+          },
+        ],
+        "cpu_platform":         true,
+        "current_status":       true,
+        "guest_accelerator":    true,
+        "id":                   true,
+        "instance_id":          true,
+        "label_fingerprint":    true,
+        "metadata_fingerprint": true,
+        "min_cpu_platform":     true,
+        "network_interface": [
+          {
+            "access_config": [
+              {
+                "nat_ip":       true,
+                "network_tier": true,
+              },
+            ],
+            "alias_ip_range":     [],
+            "name":               true,
+            "network_ip":         true,
+            "subnetwork":         true,
+            "subnetwork_project": true,
+          },
+        ],
+        "project":      true,
+        "scheduling":   true,
+        "scratch_disk": [],
+        "self_link":    true,
+        "service_account": [
+          {
+            "email": true,
+            "scopes": [
+              false,
+              false,
+              false,
+            ],
+          },
+        ],
+        "shielded_instance_config": [],
+        "tags_fingerprint":         true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "demo_1",
+    "provider_name":  "google",
+    "type":           "google_compute_instance",
+  },
+}
+output_changes = {
+  "external_ip_1": {
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after":         undefined,
+      "after_unknown": true,
+      "before":        null,
+    },
+    "name": "external_ip_1",
+  },
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-gcp-instance-image-a/mock-tfplan-fail-invalid-image.sentinel
+terraform_version = "0.12.24"
+resource_changes = {
+  "google_compute_instance.demo": {
+    "address": "google_compute_instance.demo",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "allow_stopping_for_update": null,
+        "attached_disk":             [],
+        "boot_disk": [
+          {
+            "auto_delete":             true,
+            "disk_encryption_key_raw": null,
+            "initialize_params": [
+              {
+                "image": "centos-cloud/centos-7",
+              },
+            ],
+            "mode": "READ_WRITE",
+          },
+        ],
+        "can_ip_forward":          false,
+        "deletion_protection":     false,
+        "description":             null,
+        "desired_status":          null,
+        "enable_display":          null,
+        "hostname":                null,
+        "labels":                  null,
+        "machine_type":            "n1-standard-1",
+        "metadata":                null,
+        "metadata_startup_script": null,
+        "name": "demo",
+        "network_interface": [
+          {
+            "access_config": [
+              {
+                "public_ptr_domain_name": null,
+              },
+            ],
+            "alias_ip_range": [],
+            "network":        "default",
+          },
+        ],
+        "scratch_disk":             [],
+        "service_account":          [],
+        "shielded_instance_config": [],
+        "tags":     null,
+        "timeouts": null,
+        "zone":     "us-east1-b",
+      },
+      "after_unknown": {
+        "attached_disk": [],
+        "boot_disk": [
+          {
+            "device_name":                true,
+            "disk_encryption_key_sha256": true,
+            "initialize_params": [
+              {
+                "labels": true,
+                "size":   true,
+                "type":   true,
+              },
+            ],
+            "kms_key_self_link": true,
+            "source":            true,
+          },
+        ],
+        "cpu_platform":         true,
+        "current_status":       true,
+        "guest_accelerator":    true,
+        "id":                   true,
+        "instance_id":          true,
+        "label_fingerprint":    true,
+        "metadata_fingerprint": true,
+        "min_cpu_platform":     true,
+        "network_interface": [
+          {
+            "access_config": [
+              {
+                "nat_ip":       true,
+                "network_tier": true,
+              },
+            ],
+            "alias_ip_range":     [],
+            "name":               true,
+            "network_ip":         true,
+            "subnetwork":         true,
+            "subnetwork_project": true,
+          },
+        ],
+        "project":                  true,
+        "scheduling":               true,
+        "scratch_disk":             [],
+        "self_link":                true,
+        "service_account":          [],
+        "shielded_instance_config": [],
+        "tags_fingerprint":         true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "demo",
+    "provider_name":  "google",
+    "type":           "google_compute_instance",
+  },
+}
+output_changes = {
+  "external_ip": {
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after":         undefined,
+      "after_unknown": true,
+      "before":        null,
+    },
+    "name": "external_ip",
+  },
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-gcp-instance-image-a/mock-tfplan-pass.sentinel
+terraform_version = "0.12.24"
+resource_changes = {
+  "google_compute_instance.demo": {
+    "address": "google_compute_instance.demo",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "allow_stopping_for_update": null,
+        "attached_disk":             [],
+        "boot_disk": [
+          {
+            "auto_delete":             true,
+            "disk_encryption_key_raw": null,
+            "initialize_params": [
+              {
+                "image": "debian-cloud/debian-9",
+              },
+            ],
+            "mode": "READ_WRITE",
+          },
+        ],
+        "can_ip_forward":          false,
+        "deletion_protection":     false,
+        "description":             null,
+        "desired_status":          null,
+        "enable_display":          null,
+        "hostname":                null,
+        "labels":                  null,
+        "machine_type":            "n1-standard-1",
+        "metadata":                null,
+        "metadata_startup_script": null,
+        "name": "demo",
+        "network_interface": [
+          {
+            "access_config": [
+              {
+                "public_ptr_domain_name": null,
+              },
+            ],
+            "alias_ip_range": [],
+            "network":        "default",
+          },
+        ],
+        "scratch_disk":             [],
+        "service_account":          [],
+        "shielded_instance_config": [],
+        "tags":     null,
+        "timeouts": null,
+        "zone":     "us-east1-b",
+      },
+      "after_unknown": {
+        "attached_disk": [],
+        "boot_disk": [
+          {
+            "device_name":                true,
+            "disk_encryption_key_sha256": true,
+            "initialize_params": [
+              {
+                "labels": true,
+                "size":   true,
+                "type":   true,
+              },
+            ],
+            "kms_key_self_link": true,
+            "source":            true,
+          },
+        ],
+        "cpu_platform":         true,
+        "current_status":       true,
+        "guest_accelerator":    true,
+        "id":                   true,
+        "instance_id":          true,
+        "label_fingerprint":    true,
+        "metadata_fingerprint": true,
+        "min_cpu_platform":     true,
+        "network_interface": [
+          {
+            "access_config": [
+              {
+                "nat_ip":       true,
+                "network_tier": true,
+              },
+            ],
+            "alias_ip_range":     [],
+            "name":               true,
+            "network_ip":         true,
+            "subnetwork":         true,
+            "subnetwork_project": true,
+          },
+        ],
+        "project":                  true,
+        "scheduling":               true,
+        "scratch_disk":             [],
+        "self_link":                true,
+        "service_account":          [],
+        "shielded_instance_config": [],
+        "tags_fingerprint":         true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "demo",
+    "provider_name":  "google",
+    "type":           "google_compute_instance",
+  },
+}
+output_changes = {
+  "external_ip": {
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after":         undefined,
+      "after_unknown": true,
+      "before":        null,
+    },
+    "name": "external_ip",
+  },
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-gcp-instance-image-a/pass.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}
+EOF
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-4a/solve-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-4a/solve-sentinel
@@ -1,0 +1,17 @@
+#!/bin/bash -l
+
+# Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+cd /root/sentinel
+
+# Edit the first version of the policy
+sed -i 's/<resource_type>/google_compute_instance/g' restrict-gcp-instance-image-a.sentinel
+sed -i 's/<expression_1>/boot_disk.0.initialize_params.0.image/g' restrict-gcp-instance-image-a.sentinel
+sed -i 's/<expression_2>/length(violatingGCPComputeInstances["messages"])/g' restrict-gcp-instance-image-a.sentinel
+
+# Test the second version of the policy
+sentinel test -run=image-a.sentinel -verbose
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-4b/check-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-4b/check-sentinel
@@ -1,0 +1,40 @@
+#!/bin/bash -l
+
+set -e
+
+# Run 'touch /tmp/skip-check' to disable this check
+if [ -f /tmp/skip-check ]; then
+  rm /tmp/skip-check
+  exit 0
+fi
+
+cd /root/sentinel
+
+grep -qL "<expression_1>" restrict-gcp-instance-image-b.sentinel && fail-message "You have not replaced '<expression_1>' in restrict-gcp-instance-image-b.sentinel yet."
+
+fgrep -q "instance.change.after.boot_disk" restrict-gcp-instance-image-b.sentinel || fail-message "You have not replaced '<expression_1>' with 'instance.change.after.boot_disk' in restrict-gcp-instance-image-b.sentinel yet."
+
+grep -qL "<expression_2>" restrict-gcp-instance-image-b.sentinel && fail-message "You have not replaced '<expression_2>' in restrict-gcp-instance-image-b.sentinel yet."
+
+fgrep -q "boot_disk[0].initialize_params" restrict-gcp-instance-image-b.sentinel || fail-message "You have not replaced '<expression_2>' with 'boot_disk[0].initialize_params' in restrict-gcp-instance-image-b.sentinel yet."
+
+grep -qL "<expression_3>" restrict-gcp-instance-image-b.sentinel && fail-message "You have not replaced '<expression_3>' in restrict-gcp-instance-image-b.sentinel yet."
+
+matches=$(fgrep "boot_disk[0].initialize_params[0].image" restrict-gcp-instance-image-b.sentinel | wc -l)
+if [ $matches -ne 2 ]; then
+    fail-message "You have not replaced both occurences of '<expression_3>' with 'boot_disk[0].initialize_params[0].image' in restrict-gcp-instance-image-b.sentinel yet."
+fi
+
+grep -qL "<add_main_rule>" restrict-gcp-instance-image-b.sentinel && fail-message "You have not replaced '<add_main_rule>' in restrict-gcp-instance-image-b.sentinel yet."
+
+grep -q "main = rule {" restrict-gcp-instance-image-b.sentinel || fail-message "You have not added 'main = rule {' in restrict-gcp-instance-image-b.sentinel yet."
+
+grep -q "violations is 0" restrict-gcp-instance-image-b.sentinel || grep -q "violations == 0" restrict-gcp-instance-image-b.sentinel || fail-message "You have not added 'violations is 0' or 'violations == 0' to your main rule in restrict-gcp-instance-image-b.sentinel yet."
+
+sentinel test -run=image-b.sentinel
+rc=$?
+if [ $rc -ne 0 ]; then
+    fail-message "Your policy restrict-gcp-instance-image-b.sentinel did not pass both test cases. Please revise and test it again."
+fi
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-4b/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-4b/setup-sentinel
@@ -1,0 +1,544 @@
+#!/bin/bash -l
+
+set -e
+
+cat <<-'EOF' > /root/sentinel/restrict-gcp-instance-image-b.sentinel
+# This policy restricts the public images that GCP compute instances use
+
+# Import the v2 tfplan import, but use the alias "tfplan"
+import "tfplan/v2" as tfplan
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# Standard types import
+import "types"
+
+# Get all GCP compute instances
+allGCPComputeInstances = plan.find_resources("google_compute_instance")
+
+# Function to restrict images used by GCP compute instances
+filter_images = func(instances, image) {
+
+  # Create empty list of violators
+  violators = {}
+
+  # Iterate over instances to check their images
+  for instances as address, instance {
+    # Set boot_disk variable
+    boot_disk = <expression_1>
+    # Validate that the initialize_params block is present and a list
+    # and that the image under it is allowed
+    # Add violators to the violators list and print warnings
+    if types.type_of(<expression_2>) is not "list" {
+      violators[address] = instance
+      print(address, "does not have image defined: it should be", image)
+    } else if <expression_3> is not image {
+      violators[address] = instance
+      print(address, "has image", <expression_3>,
+            "but is supposed to use", image)
+    } // end if
+  } // end for
+
+  return violators
+
+}
+
+# Filter to violating GCP instances
+violatingGCPComputeInstances = filter_images(allGCPComputeInstances, "debian-cloud/debian-9")
+
+# Count violations
+violations = length(violatingGCPComputeInstances)
+
+# Main rule
+<add_main_rule>
+EOF
+
+mkdir -p /root/sentinel/test/restrict-gcp-instance-image-b
+
+cat <<-'EOF' > /root/sentinel/test/restrict-gcp-instance-image-b/fail-no-initialize-params.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-no-initialize-params.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-gcp-instance-image-b/fail-invalid-image.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-fail-invalid-image.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-gcp-instance-image-b/mock-tfplan-fail-no-initialize-params.sentinel
+terraform_version = "0.12.24"
+resource_changes = {
+  "google_compute_disk.default": {
+    "address": "google_compute_disk.default",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "description":         null,
+        "disk_encryption_key": [],
+        "image":               "debian-cloud/debian-9",
+        "labels": {
+          "environment": "dev",
+        },
+        "name": "test-disk",
+        "physical_block_size_bytes":      4096,
+        "snapshot":                       null,
+        "source_image_encryption_key":    [],
+        "source_snapshot_encryption_key": [],
+        "timeouts":                       null,
+        "type":                           "pd-ssd",
+        "zone":                           "us-east1-b",
+      },
+      "after_unknown": {
+        "creation_timestamp":  true,
+        "disk_encryption_key": [],
+        "id":                    true,
+        "label_fingerprint":     true,
+        "labels":                {},
+        "last_attach_timestamp": true,
+        "last_detach_timestamp": true,
+        "project":               true,
+        "self_link":             true,
+        "size":                  true,
+        "source_image_encryption_key":    [],
+        "source_image_id":                true,
+        "source_snapshot_encryption_key": [],
+        "source_snapshot_id":             true,
+        "users":                          true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "default",
+    "provider_name":  "google",
+    "type":           "google_compute_disk",
+  },
+  "google_compute_instance.demo_1": {
+    "address": "google_compute_instance.demo_1",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "allow_stopping_for_update": true,
+        "attached_disk":             [],
+        "boot_disk": [
+          {
+            "auto_delete":             true,
+            "disk_encryption_key_raw": null,
+            "mode": "READ_WRITE",
+          },
+        ],
+        "can_ip_forward":          false,
+        "deletion_protection":     false,
+        "description":             null,
+        "desired_status":          null,
+        "enable_display":          null,
+        "hostname":                null,
+        "labels":                  null,
+        "machine_type":            "n1-standard-1",
+        "metadata":                null,
+        "metadata_startup_script": null,
+        "name": "demo-1",
+        "network_interface": [
+          {
+            "access_config": [
+              {
+                "public_ptr_domain_name": null,
+              },
+            ],
+            "alias_ip_range": [],
+            "network":        "default",
+          },
+        ],
+        "scratch_disk": [],
+        "service_account": [
+          {
+            "scopes": [
+              "https://www.googleapis.com/auth/compute.readonly",
+              "https://www.googleapis.com/auth/monitoring",
+              "https://www.googleapis.com/auth/servicecontrol",
+            ],
+          },
+        ],
+        "shielded_instance_config": [],
+        "tags":     null,
+        "timeouts": null,
+        "zone":     "us-east1-b",
+      },
+      "after_unknown": {
+        "attached_disk": [],
+        "boot_disk": [
+          {
+            "device_name":                true,
+            "disk_encryption_key_sha256": true,
+            "initialize_params":          true,
+            "kms_key_self_link":          true,
+            "source":                     true,
+          },
+        ],
+        "cpu_platform":         true,
+        "current_status":       true,
+        "guest_accelerator":    true,
+        "id":                   true,
+        "instance_id":          true,
+        "label_fingerprint":    true,
+        "metadata_fingerprint": true,
+        "min_cpu_platform":     true,
+        "network_interface": [
+          {
+            "access_config": [
+              {
+                "nat_ip":       true,
+                "network_tier": true,
+              },
+            ],
+            "alias_ip_range":     [],
+            "name":               true,
+            "network_ip":         true,
+            "subnetwork":         true,
+            "subnetwork_project": true,
+          },
+        ],
+        "project":      true,
+        "scheduling":   true,
+        "scratch_disk": [],
+        "self_link":    true,
+        "service_account": [
+          {
+            "email": true,
+            "scopes": [
+              false,
+              false,
+              false,
+            ],
+          },
+        ],
+        "shielded_instance_config": [],
+        "tags_fingerprint":         true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "demo_1",
+    "provider_name":  "google",
+    "type":           "google_compute_instance",
+  },
+}
+output_changes = {
+  "external_ip_1": {
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after":         undefined,
+      "after_unknown": true,
+      "before":        null,
+    },
+    "name": "external_ip_1",
+  },
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-gcp-instance-image-b/mock-tfplan-fail-invalid-image.sentinel
+terraform_version = "0.12.24"
+resource_changes = {
+  "google_compute_instance.demo": {
+    "address": "google_compute_instance.demo",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "allow_stopping_for_update": null,
+        "attached_disk":             [],
+        "boot_disk": [
+          {
+            "auto_delete":             true,
+            "disk_encryption_key_raw": null,
+            "initialize_params": [
+              {
+                "image": "centos-cloud/centos-7",
+              },
+            ],
+            "mode": "READ_WRITE",
+          },
+        ],
+        "can_ip_forward":          false,
+        "deletion_protection":     false,
+        "description":             null,
+        "desired_status":          null,
+        "enable_display":          null,
+        "hostname":                null,
+        "labels":                  null,
+        "machine_type":            "n1-standard-1",
+        "metadata":                null,
+        "metadata_startup_script": null,
+        "name": "demo",
+        "network_interface": [
+          {
+            "access_config": [
+              {
+                "public_ptr_domain_name": null,
+              },
+            ],
+            "alias_ip_range": [],
+            "network":        "default",
+          },
+        ],
+        "scratch_disk":             [],
+        "service_account":          [],
+        "shielded_instance_config": [],
+        "tags":     null,
+        "timeouts": null,
+        "zone":     "us-east1-b",
+      },
+      "after_unknown": {
+        "attached_disk": [],
+        "boot_disk": [
+          {
+            "device_name":                true,
+            "disk_encryption_key_sha256": true,
+            "initialize_params": [
+              {
+                "labels": true,
+                "size":   true,
+                "type":   true,
+              },
+            ],
+            "kms_key_self_link": true,
+            "source":            true,
+          },
+        ],
+        "cpu_platform":         true,
+        "current_status":       true,
+        "guest_accelerator":    true,
+        "id":                   true,
+        "instance_id":          true,
+        "label_fingerprint":    true,
+        "metadata_fingerprint": true,
+        "min_cpu_platform":     true,
+        "network_interface": [
+          {
+            "access_config": [
+              {
+                "nat_ip":       true,
+                "network_tier": true,
+              },
+            ],
+            "alias_ip_range":     [],
+            "name":               true,
+            "network_ip":         true,
+            "subnetwork":         true,
+            "subnetwork_project": true,
+          },
+        ],
+        "project":                  true,
+        "scheduling":               true,
+        "scratch_disk":             [],
+        "self_link":                true,
+        "service_account":          [],
+        "shielded_instance_config": [],
+        "tags_fingerprint":         true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "demo",
+    "provider_name":  "google",
+    "type":           "google_compute_instance",
+  },
+}
+output_changes = {
+  "external_ip": {
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after":         undefined,
+      "after_unknown": true,
+      "before":        null,
+    },
+    "name": "external_ip",
+  },
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-gcp-instance-image-b/mock-tfplan-pass.sentinel
+terraform_version = "0.12.24"
+resource_changes = {
+  "google_compute_instance.demo": {
+    "address": "google_compute_instance.demo",
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after": {
+        "allow_stopping_for_update": null,
+        "attached_disk":             [],
+        "boot_disk": [
+          {
+            "auto_delete":             true,
+            "disk_encryption_key_raw": null,
+            "initialize_params": [
+              {
+                "image": "debian-cloud/debian-9",
+              },
+            ],
+            "mode": "READ_WRITE",
+          },
+        ],
+        "can_ip_forward":          false,
+        "deletion_protection":     false,
+        "description":             null,
+        "desired_status":          null,
+        "enable_display":          null,
+        "hostname":                null,
+        "labels":                  null,
+        "machine_type":            "n1-standard-1",
+        "metadata":                null,
+        "metadata_startup_script": null,
+        "name": "demo",
+        "network_interface": [
+          {
+            "access_config": [
+              {
+                "public_ptr_domain_name": null,
+              },
+            ],
+            "alias_ip_range": [],
+            "network":        "default",
+          },
+        ],
+        "scratch_disk":             [],
+        "service_account":          [],
+        "shielded_instance_config": [],
+        "tags":     null,
+        "timeouts": null,
+        "zone":     "us-east1-b",
+      },
+      "after_unknown": {
+        "attached_disk": [],
+        "boot_disk": [
+          {
+            "device_name":                true,
+            "disk_encryption_key_sha256": true,
+            "initialize_params": [
+              {
+                "labels": true,
+                "size":   true,
+                "type":   true,
+              },
+            ],
+            "kms_key_self_link": true,
+            "source":            true,
+          },
+        ],
+        "cpu_platform":         true,
+        "current_status":       true,
+        "guest_accelerator":    true,
+        "id":                   true,
+        "instance_id":          true,
+        "label_fingerprint":    true,
+        "metadata_fingerprint": true,
+        "min_cpu_platform":     true,
+        "network_interface": [
+          {
+            "access_config": [
+              {
+                "nat_ip":       true,
+                "network_tier": true,
+              },
+            ],
+            "alias_ip_range":     [],
+            "name":               true,
+            "network_ip":         true,
+            "subnetwork":         true,
+            "subnetwork_project": true,
+          },
+        ],
+        "project":                  true,
+        "scheduling":               true,
+        "scratch_disk":             [],
+        "self_link":                true,
+        "service_account":          [],
+        "shielded_instance_config": [],
+        "tags_fingerprint":         true,
+      },
+      "before": null,
+    },
+    "deposed":        "",
+    "index":          null,
+    "mode":           "managed",
+    "module_address": "",
+    "name":           "demo",
+    "provider_name":  "google",
+    "type":           "google_compute_instance",
+  },
+}
+output_changes = {
+  "external_ip": {
+    "change": {
+      "actions": [
+        "create",
+      ],
+      "after":         undefined,
+      "after_unknown": true,
+      "before":        null,
+    },
+    "name": "external_ip",
+  },
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/restrict-gcp-instance-image-b/pass.json
+{
+  "modules": {
+    "tfplan-functions": {
+      "path": "../../common-functions/tfplan-functions/tfplan-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfplan/v2": "mock-tfplan-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}
+EOF
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-4b/solve-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-4b/solve-sentinel
@@ -1,0 +1,18 @@
+#!/bin/bash -l
+
+# Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+cd /root/sentinel
+
+# Edit the second version of the policy
+sed -i 's/<expression_1>/instance.change.after.boot_disk/g' restrict-gcp-instance-image-b.sentinel
+sed -i 's/<expression_2>/boot_disk[0].initialize_params/g' restrict-gcp-instance-image-b.sentinel
+sed -i 's/<expression_3>/boot_disk[0].initialize_params[0].image/g' restrict-gcp-instance-image-b.sentinel
+sed -i 's/<add_main_rule>/main = rule { violations is 0 }/g' restrict-gcp-instance-image-b.sentinel
+
+# Test the second version of the policy
+sentinel test -run=image-b.sentinel -verbose
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-5a/check-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-5a/check-sentinel
@@ -1,0 +1,49 @@
+#!/bin/bash -l
+
+set -e
+
+cd /root/sentinel
+
+fgrep -qL "<expression_1>" require-modules-from-pmr-a.sentinel && fail-message "You have not replaced '<expression_1>' in require-modules-from-pmr-a.sentinel with an expression that gives a list of all module calls yet."
+
+fgrep -q "tfconfig.module_calls" require-modules-from-pmr-a.sentinel || fail-message "You have not replaced '<expression_1>' in require-modules-from-pmr-a.sentinel with 'tfconfig.module_calls' yet."
+
+fgrep -qL "<condition_1>" require-modules-from-pmr-a.sentinel && fail-message "You have not replaced '<condition_1>' in require-modules-from-pmr-a.sentinel with a condition that requires the current module call to have an index that does not contain a colon yet."
+
+fgrep -q 'index not matches "(.+):(.+)"' require-modules-from-pmr-a.sentinel || fgrep -q 'index not matches ".+:.+"' require-modules-from-pmr-a.sentinel || fgrep -q 'index matches "^[^:]*$"' require-modules-from-pmr-a.sentinel || fail-message "You have not replaced '<condition_1>' with 'index not matches \"(.+):(.+)\"' or 'index matches \"^[^:]*$\"' yet."
+
+fgrep -qL "<condition_2>" require-modules-from-pmr-a.sentinel && fail-message "You have not replaced '<condition_2>' in require-modules-from-pmr-a.sentinel with a condition that tests if the module call has a source from the desired private module registry yet."
+
+fgrep -q 'strings.has_prefix(mc.source, tf_address + "/" + tf_org)' require-modules-from-pmr-a.sentinel || fail-message "You have not replaced '<condition_2>' with 'strings.has_prefix(mc.source, tf_address + \"/\" + tf_org)' yet."
+
+fgrep -qL "<expression_2>" require-modules-from-pmr-a.sentinel && fail-message "You have not replaced '<expression_2>' in require-modules-from-pmr-a.sentinel with an expression that gives the source of the module yet."
+
+fgrep -q "mc.source" require-modules-from-pmr-a.sentinel || fail-message "You have not replace '<expression_2>' in require-modules-from-pmr-a.sentinel with 'mc.source' yet."
+
+matches=$(fgrep "mc.source" require-modules-from-pmr-a.sentinel | wc -l)
+if [ $matches -ne 2 ]; then
+    fail-message "You need to replace '<expression_2>' in require-modules-from-pmr-a.sentinel with 'mc.source'."
+fi
+
+fgrep -qL "<function>" require-modules-from-pmr-a.sentinel && fail-message "You have not replaced '<function>' in require-modules-from-pmr-a.sentinel with the function that should be called yet."
+
+matches=$(fgrep "require_modules_from_pmr" require-modules-from-pmr-a.sentinel | wc -l)
+if [ $matches -ne 2 ]; then
+    fail-message "You need to replace '<function>' in require-modules-from-pmr-a.sentinel with 'require_modules_from_pmr'."
+fi
+
+fgrep -qL "<arg1>" require-modules-from-pmr-a.sentinel && fail-message "You have not replaced '<arg1>' in require-modules-from-pmr-a.sentinel yet."
+
+fgrep -qL "<arg2>" require-modules-from-pmr-a.sentinel && fail-message "You have not replaced '<arg2>' in require-modules-from-pmr-a.sentinel yet."
+
+fgrep -q "require_modules_from_pmr(address, organization)" require-modules-from-pmr-a.sentinel || fail-message "You have not replaced '<function>(<arg1>, <arg2>)' with 'require_modules_from_pmr(address, organization)' in require-modules-from-pmr-a.sentinel yet."
+
+fgrep -q "sentinel test -run=pmr-a.sentinel -verbose" /root/.bash_history || fgrep -q "sentinel test -run=pmr-a.sentinel" /root/.bash_history || fail-message "You haven't tested the require-modules-from-pmr-a.sentinel policy against the test cases yet. Please run 'sentinel test -run=pmr-a.sentinel -verbose'"
+
+sentinel test -run=pmr-a.sentinel
+rc=$?
+if [ $rc -ne 0 ]; then
+    fail-message "Your policy require-modules-from-pmr-a.sentinel did not pass both test cases. Please revise and test it again."
+fi
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-5a/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-5a/setup-sentinel
@@ -1,0 +1,278 @@
+#!/bin/bash -l
+
+set -e
+
+cat <<-'EOF' > /root/sentinel/require-modules-from-pmr-a.sentinel
+# This policy validates that all modules loaded directly by the
+# root module are in the Private Module Registry (PMR) of a TFC
+# organization.
+
+# Import the v2 tfplan import, but use the alias "tfplan"
+import "tfconfig/v2" as tfconfig
+
+# Standard strings import
+import "strings"
+
+##### Parameters #####
+# The address of the TFC or TFE server
+param address default "app.terraform.io"
+
+# The organization on the TFC or TFE server
+param organization
+
+# Require all modules directly under root module to come from PMR
+require_modules_from_pmr = func(tf_address, tf_org) {
+
+  validated = true
+
+  # Iterate over all modules but focus on calls from the root module.
+  # A module call represents one module referencing another module
+  # with a module block.
+  for <expression_1> as index, mc {
+    # Ignore modules with index matching "<address>:<name>"
+    # since these are not called from the root module.
+    if <condition_1> {
+      if not <condition_2> {
+        print("Your root module called the module", index, "with source", <expression_2>)
+        validated = false
+      } // end second if
+    } // end first if
+  } // end for
+
+  if not validated {
+    print("All modules called from the root module must come from the",
+          "private module registry", tf_address + "/" + tf_org)
+  }
+
+  return validated
+}
+
+# Call the validation function
+modules_from_pmr = <function>(<arg1>, <arg2>)
+
+# Main rule
+main = rule {
+  modules_from_pmr
+}
+EOF
+
+mkdir -p /root/sentinel/test/require-modules-from-pmr-a
+
+cat <<-'EOF' > /root/sentinel/test/require-modules-from-pmr-a/fail.json
+{
+  "param": {
+    "organization": "Cloud-Operations"
+  },
+  "mock": {
+    "tfconfig/v2": "mock-tfconfig-fail.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-modules-from-pmr-a/mock-tfconfig-fail.sentinel
+
+module_calls = {
+  "module.windowsserver:os": {
+    "config": {
+      "vm_os_simple": {
+        "references": [
+          "var.vm_os_simple",
+        ],
+      },
+    },
+    "count":              {},
+    "for_each":           {},
+    "module_address":     "module.windowsserver",
+    "name":               "os",
+    "source":             "./os",
+    "version_constraint": "",
+  },
+  "network": {
+    "config": {
+      "allow_ssh_traffic": {
+        "constant_value": true,
+      },
+      "location": {
+        "references": [
+          "var.location",
+        ],
+      },
+      "resource_group_name": {
+        "references": [
+          "var.windows_dns_prefix",
+        ],
+      },
+    },
+    "count":              {},
+    "for_each":           {},
+    "module_address":     "",
+    "name":               "network",
+    "source":             "Azure/network/azurerm",
+    "version_constraint": "1.1.1",
+  },
+  "windowsserver": {
+    "config": {
+      "admin_password": {
+        "references": [
+          "var.admin_password",
+        ],
+      },
+      "location": {
+        "references": [
+          "var.location",
+        ],
+      },
+      "public_ip_dns": {
+        "references": [
+          "var.windows_dns_prefix",
+        ],
+      },
+      "resource_group_name": {
+        "references": [
+          "var.windows_dns_prefix",
+        ],
+      },
+      "storage_account_type": {
+        "references": [
+          "var.storage_account_type",
+        ],
+      },
+      "vm_hostname": {
+        "constant_value": "demohost",
+      },
+      "vm_os_simple": {
+        "constant_value": "WindowsServer",
+      },
+      "vm_size": {
+        "references": [
+          "var.vm_size",
+        ],
+      },
+      "vnet_subnet_id": {
+        "references": [
+          "module.network.vnet_subnets",
+        ],
+      },
+    },
+    "count":              {},
+    "for_each":           {},
+    "module_address":     "",
+    "name":               "windowsserver",
+    "source":             "Azure/compute/azurerm",
+    "version_constraint": "1.1.6",
+  },
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-modules-from-pmr-a/mock-tfconfig-pass.sentinel
+module_calls = {
+  "module.windowsserver:os": {
+    "config": {
+      "vm_os_simple": {
+        "references": [
+          "var.vm_os_simple",
+        ],
+      },
+    },
+    "count":              {},
+    "for_each":           {},
+    "module_address":     "module.windowsserver",
+    "name":               "os",
+    "source":             "./os",
+    "version_constraint": "",
+  },
+  "network": {
+    "config": {
+      "allow_ssh_traffic": {
+        "constant_value": true,
+      },
+      "location": {
+        "references": [
+          "var.location",
+        ],
+      },
+      "resource_group_name": {
+        "references": [
+          "var.windows_dns_prefix",
+        ],
+      },
+    },
+    "count":              {},
+    "for_each":           {},
+    "module_address":     "",
+    "name":               "network",
+    "source":             "app.terraform.io/Cloud-Operations/network/azurerm",
+    "version_constraint": "1.1.1",
+  },
+  "windowsserver": {
+    "config": {
+      "admin_password": {
+        "references": [
+          "var.admin_password",
+        ],
+      },
+      "location": {
+        "references": [
+          "var.location",
+        ],
+      },
+      "public_ip_dns": {
+        "references": [
+          "var.windows_dns_prefix",
+        ],
+      },
+      "resource_group_name": {
+        "references": [
+          "var.windows_dns_prefix",
+        ],
+      },
+      "storage_account_type": {
+        "references": [
+          "var.storage_account_type",
+        ],
+      },
+      "vm_hostname": {
+        "constant_value": "demohost",
+      },
+      "vm_os_simple": {
+        "constant_value": "WindowsServer",
+      },
+      "vm_size": {
+        "references": [
+          "var.vm_size",
+        ],
+      },
+      "vnet_subnet_id": {
+        "references": [
+          "module.network.vnet_subnets",
+        ],
+      },
+    },
+    "count":              {},
+    "for_each":           {},
+    "module_address":     "",
+    "name":               "windowsserver",
+    "source":             "app.terraform.io/Cloud-Operations/compute/azurerm",
+    "version_constraint": "1.1.6",
+  },
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-modules-from-pmr-a/pass.json
+{
+  "param": {
+    "organization": "Cloud-Operations"
+  },
+  "mock": {
+    "tfconfig/v2": "mock-tfconfig-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}
+EOF
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-5a/solve-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-5a/solve-sentinel
@@ -1,0 +1,21 @@
+#!/bin/bash -l
+
+# Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+cd /root/sentinel
+
+# Edit the first version of the policy
+sed -i 's/<expression_1>/tfconfig.module_calls/g' require-modules-from-pmr-a.sentinel
+sed -i 's/<condition_1>/index not matches "(.+):(.+)"/g' require-modules-from-pmr-a.sentinel
+sed -i 's:<condition_2>:strings.has_prefix(mc.source, tf_address + "/" + tf_org):g' require-modules-from-pmr-a.sentinel
+sed -i 's/<expression_2>/mc.source/g' require-modules-from-pmr-a.sentinel
+sed -i 's/<function>/require_modules_from_pmr/g' require-modules-from-pmr-a.sentinel
+sed -i 's/<arg1>/address/g' require-modules-from-pmr-a.sentinel
+sed -i 's/<arg2>/organization/g' require-modules-from-pmr-a.sentinel
+
+# Test the first version of the policy
+sentinel test -run=pmr-a.sentinel -verbose
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-5b/check-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-5b/check-sentinel
@@ -1,0 +1,23 @@
+#!/bin/bash -l
+
+set -e
+
+cd /root/sentinel
+
+fgrep -q "require_modules_from_pmr = func(tf_address, tf_org)" common-functions/module-functions/module-functions.sentinel || fail-message "You have not copied the 'require_modules_from_pmr' function into common-functions/module-functions/module-functions.sentinel yet."
+
+fgrep -qL "<import_statement>" require-modules-from-pmr-b.sentinel && fail-message "You have not replaced '<import_statement>' with an import statement in require-modules-from-pmr-b.sentinel yet."
+
+fgrep -q 'import "module-functions" as modules' require-modules-from-pmr-b.sentinel || fail-message "You have not replaced '<import_statement>' with 'import "module-functions" as modules' in require-modules-from-pmr-b.sentinel yet."
+
+fgrep -qL "<function_call>" require-modules-from-pmr-b.sentinel && fail-message "You have not replaced '<function_call>' with a call to the function 'require_modules_from_pmr' in require-modules-from-pmr-b.sentinel yet."
+
+fgrep -q 'modules.require_modules_from_pmr(address, organization)' require-modules-from-pmr-b.sentinel || fail-message "You have not replaced '<function_call>' with 'modules.require_modules_from_pmr(address, organization)' in require-modules-from-pmr-b.sentinel yet."
+
+sentinel test -run=pmr-b.sentinel
+rc=$?
+if [ $rc -ne 0 ]; then
+    fail-message "Your policy require-modules-from-pmr-b.sentinel did not pass both test cases. Please revise and test it again."
+fi
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-5b/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-5b/setup-sentinel
@@ -1,0 +1,276 @@
+#!/bin/bash -l
+
+set -e
+
+# module-functions
+mkdir -p /root/sentinel/common-functions/module-functions
+
+cat <<-'EOF' > /root/sentinel/require-modules-from-pmr-b.sentinel
+# This policy validates that all modules loaded directly by the
+# root module are in the Private Module Registry (PMR) of a TFC
+# organization.
+
+# Import the v2 tfplan import, but use the alias "tfplan"
+import "tfconfig/v2" as tfconfig
+
+# Import module-functions.sentinel as "modules"
+<import_statement>
+
+##### Parameters #####
+# The address of the TFC or TFE server
+param address default "app.terraform.io"
+
+# The organization on the TFC or TFE server
+param organization
+
+# Call the validation function
+modules_from_pmr = <function_call>
+
+# Main rule
+main = rule {
+  modules_from_pmr
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/common-functions/module-functions/module-functions.sentinel
+# Functions that use the tfconfig import to restrict modules
+
+##### Imports #####
+import "tfconfig/v2" as tfconfig
+import "strings"
+
+##### Functions #####
+
+
+EOF
+
+mkdir -p /root/sentinel/test/require-modules-from-pmr-b
+
+cat <<-'EOF' > /root/sentinel/test/require-modules-from-pmr-b/fail.json
+{
+  "param": {
+    "organization": "Cloud-Operations"
+  },
+  "modules": {
+    "module-functions": {
+      "path": "../../common-functions/module-functions/module-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfconfig/v2": "mock-tfconfig-fail.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-modules-from-pmr-b/mock-tfconfig-fail.sentinel
+
+module_calls = {
+  "module.windowsserver:os": {
+    "config": {
+      "vm_os_simple": {
+        "references": [
+          "var.vm_os_simple",
+        ],
+      },
+    },
+    "count":              {},
+    "for_each":           {},
+    "module_address":     "module.windowsserver",
+    "name":               "os",
+    "source":             "./os",
+    "version_constraint": "",
+  },
+  "network": {
+    "config": {
+      "allow_ssh_traffic": {
+        "constant_value": true,
+      },
+      "location": {
+        "references": [
+          "var.location",
+        ],
+      },
+      "resource_group_name": {
+        "references": [
+          "var.windows_dns_prefix",
+        ],
+      },
+    },
+    "count":              {},
+    "for_each":           {},
+    "module_address":     "",
+    "name":               "network",
+    "source":             "Azure/network/azurerm",
+    "version_constraint": "1.1.1",
+  },
+  "windowsserver": {
+    "config": {
+      "admin_password": {
+        "references": [
+          "var.admin_password",
+        ],
+      },
+      "location": {
+        "references": [
+          "var.location",
+        ],
+      },
+      "public_ip_dns": {
+        "references": [
+          "var.windows_dns_prefix",
+        ],
+      },
+      "resource_group_name": {
+        "references": [
+          "var.windows_dns_prefix",
+        ],
+      },
+      "storage_account_type": {
+        "references": [
+          "var.storage_account_type",
+        ],
+      },
+      "vm_hostname": {
+        "constant_value": "demohost",
+      },
+      "vm_os_simple": {
+        "constant_value": "WindowsServer",
+      },
+      "vm_size": {
+        "references": [
+          "var.vm_size",
+        ],
+      },
+      "vnet_subnet_id": {
+        "references": [
+          "module.network.vnet_subnets",
+        ],
+      },
+    },
+    "count":              {},
+    "for_each":           {},
+    "module_address":     "",
+    "name":               "windowsserver",
+    "source":             "Azure/compute/azurerm",
+    "version_constraint": "1.1.6",
+  },
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-modules-from-pmr-b/mock-tfconfig-pass.sentinel
+module_calls = {
+  "module.windowsserver:os": {
+    "config": {
+      "vm_os_simple": {
+        "references": [
+          "var.vm_os_simple",
+        ],
+      },
+    },
+    "count":              {},
+    "for_each":           {},
+    "module_address":     "module.windowsserver",
+    "name":               "os",
+    "source":             "./os",
+    "version_constraint": "",
+  },
+  "network": {
+    "config": {
+      "allow_ssh_traffic": {
+        "constant_value": true,
+      },
+      "location": {
+        "references": [
+          "var.location",
+        ],
+      },
+      "resource_group_name": {
+        "references": [
+          "var.windows_dns_prefix",
+        ],
+      },
+    },
+    "count":              {},
+    "for_each":           {},
+    "module_address":     "",
+    "name":               "network",
+    "source":             "app.terraform.io/Cloud-Operations/network/azurerm",
+    "version_constraint": "1.1.1",
+  },
+  "windowsserver": {
+    "config": {
+      "admin_password": {
+        "references": [
+          "var.admin_password",
+        ],
+      },
+      "location": {
+        "references": [
+          "var.location",
+        ],
+      },
+      "public_ip_dns": {
+        "references": [
+          "var.windows_dns_prefix",
+        ],
+      },
+      "resource_group_name": {
+        "references": [
+          "var.windows_dns_prefix",
+        ],
+      },
+      "storage_account_type": {
+        "references": [
+          "var.storage_account_type",
+        ],
+      },
+      "vm_hostname": {
+        "constant_value": "demohost",
+      },
+      "vm_os_simple": {
+        "constant_value": "WindowsServer",
+      },
+      "vm_size": {
+        "references": [
+          "var.vm_size",
+        ],
+      },
+      "vnet_subnet_id": {
+        "references": [
+          "module.network.vnet_subnets",
+        ],
+      },
+    },
+    "count":              {},
+    "for_each":           {},
+    "module_address":     "",
+    "name":               "windowsserver",
+    "source":             "app.terraform.io/Cloud-Operations/compute/azurerm",
+    "version_constraint": "1.1.6",
+  },
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/require-modules-from-pmr-b/pass.json
+{
+  "param": {
+    "organization": "Cloud-Operations"
+  },
+  "modules": {
+    "module-functions": {
+      "path": "../../common-functions/module-functions/module-functions.sentinel"
+    }
+  },
+  "mock": {
+    "tfconfig/v2": "mock-tfconfig-pass.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}
+EOF
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-5b/solve-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-5b/solve-sentinel
@@ -1,0 +1,50 @@
+#!/bin/bash -l
+
+# Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+cd /root/sentinel
+
+# Copy require_modules_from_pmr function to module-functions.sentinel
+cat <<-'EOF' >> /root/sentinel/common-functions/module-functions/module-functions.sentinel
+# Require all modules directly under root module to come from PMR
+require_modules_from_pmr = func(tf_address, tf_org) {
+
+  validated = true
+
+  # Iterate over all modules but focus on calls from the root module.
+  # A module call represents one module referencing another module
+  # with a module block.
+  for tfconfig.module_calls as index, mc {
+    # Ignore modules with index matching "<address>:<name>"
+    # since these are not called from the root module.
+    # Since <address> would start with "module." for a non-root module,
+    # we could look for indices that do not match "^module\\.(.+):(.+)"
+    if index not matches "(.+):(.+)" {
+    # The following line could be used instead of the previous line
+    # if index matches "^[^:]*$" {
+      if not strings.has_prefix(mc.source, tf_address + "/" + tf_org) {
+        print("Your root module called the module", index, "with source", mc.source)
+        validated = false
+      } // end second if
+    } // end first if
+  } // end for
+
+  if not validated {
+    print("All modules called from the root module must come from the",
+          "private module registry", tf_address + "/" + tf_org)
+  }
+
+  return validated
+}
+EOF
+
+# Edit the second version of the policy
+sed -i 's/<import_statement>/import "module-functions" as modules/g' require-modules-from-pmr-b.sentinel
+sed -i 's/<function_call>/modules.require_modules_from_pmr(address, organization)/g' require-modules-from-pmr-b.sentinel
+
+# Test the second version of the policy
+sentinel test -run=pmr-b.sentinel -verbose
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/extra-credit/check-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/extra-credit/check-sentinel
@@ -1,0 +1,31 @@
+#!/bin/bash -l
+
+set -e
+
+cd /root/sentinel
+
+grep -qL "<condition_1>" prevent-auto-apply-in-production.sentinel && fail-message "You have not replaced '<condition_1>' with a condition yet."
+
+grep -qL "<condition_2>" prevent-auto-apply-in-production.sentinel && fail-message "You have not replaced '<condition_2>' with a condition yet."
+
+grep -q "tfrun.workspace.name matches \"^prod-(.*)\"" prevent-auto-apply-in-production.sentinel  || grep -q "strings.has_prefix(tfrun.workspace.name, \"prod-\")" prevent-auto-apply-in-production.sentinel || fail-message "You have not added 'tfrun.workspace.name matches \"^prod-(.*)\"' or 'strings.has_prefix(tfrun.workspace.name, \"prod-\")' to your conditions yet."
+
+grep -q "tfrun.workspace.name matches \"(.*)-prod$\"" prevent-auto-apply-in-production.sentinel || grep -q "strings.has_suffix(tfrun.workspace.name, \"-prod\")" prevent-auto-apply-in-production.sentinel || fail-message "You have not added 'tfrun.workspace.name matches \"(.*)-prod$\"' or 'strings.has_suffix(tfrun.workspace.name, \"-prod\")' to your conditions yet."
+
+grep -qL "<condition_3>" prevent-auto-apply-in-production.sentinel && fail-message "You have not replaced '<condition_3>' with a condition yet."
+
+grep -q "tfrun.workspace.auto_apply" prevent-auto-apply-in-production.sentinel || grep -q "tfrun.workspace.auto_apply is true" || grep -q "tfrun.workspace.auto_apply == true" || fail-message "You have not replaced '<condition_3>' with 'tfrun.workspace.auto_apply is true' (or the equivalent) yet."
+
+grep -qL "<expression_1>" prevent-auto-apply-in-production.sentinel && fail-message "You have not replaced '<expression_1>' yet."
+
+grep -q "tfrun.workspace.name" prevent-auto-apply-in-production.sentinel || fail-message "You have not replaced '<expression_1>' with 'tfrun.workspace.name' yet."
+
+grep -q "sentinel test -run=auto -verbose" /root/.bash_history || grep -q "sentinel test -run=auto" /root/.bash_history || fail-message "You haven't tested the prevent-auto-apply-in-production.sentinel policy against the test cases yet. Please run 'sentinel test -run=auto -verbose'"
+
+sentinel test -run=auto
+rc=$?
+if [ $rc -ne 0 ]; then
+    fail-message "Your policy prevent-auto-apply-in-production.sentinel did not pass all 4 test cases. Please revise and test it again."
+fi
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/extra-credit/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/extra-credit/setup-sentinel
@@ -1,0 +1,130 @@
+#!/bin/bash -l
+
+set -e
+
+cat <<-'EOF' > /root/sentinel/prevent-auto-apply-in-production.sentinel
+# This policy uses the Sentinel tfrun import to prevent the use of auto-apply
+# in workspaces with names matching "^prod-(.*)" or "(.*)-prod$"
+
+##### Imports #####
+
+import "tfrun"
+import "strings"
+
+##### Functions #####
+
+# Validate that auto-apply not set for production workspaces
+validate_auto_apply = func() {
+
+  validated = true
+
+  if <condition_1> or
+     <condition_2> {
+    if <condition_3> {
+      print("The workspace", <expression_1>, "has auto_apply set to true")
+      validated = false
+    }
+  }
+
+  return validated
+}
+
+##### Rules #####
+
+# Call the validation function
+auto_apply_validated = validate_auto_apply()
+
+# Main rule
+main = rule {
+  auto_apply_validated
+}
+EOF
+
+mkdir -p /root/sentinel/test/prevent-auto-apply-in-production
+
+cat <<-'EOF' > /root/sentinel/test/prevent-auto-apply-in-production/fail-prefix.json
+{
+  "mock": {
+    "tfrun": "mock-tfrun-fail-prefix.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/prevent-auto-apply-in-production/fail-suffix.json
+{
+  "mock": {
+    "tfrun": "mock-tfrun-fail-suffix.sentinel"
+  },
+  "test": {
+    "main": false
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/prevent-auto-apply-in-production/mock-tfrun-fail-prefix.sentinel
+workspace = {
+  "auto_apply":  true,
+  "description": null,
+  "name":        "prod-compute",
+  "vcs_repo": {},
+  "working_directory": "",
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/prevent-auto-apply-in-production/mock-tfrun-fail-suffix.sentinel
+workspace = {
+  "auto_apply":  true,
+  "description": null,
+  "name":        "compute-prod",
+  "vcs_repo": {},
+  "working_directory": "",
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/prevent-auto-apply-in-production/mock-tfrun-pass-prefix.sentinel
+workspace = {
+  "auto_apply":  false,
+  "description": null,
+  "name":        "prod-network",
+  "vcs_repo": {},
+  "working_directory": "",
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/prevent-auto-apply-in-production/mock-tfrun-pass-suffix.sentinel
+workspace = {
+  "auto_apply":  false,
+  "description": null,
+  "name":        "network-prod",
+  "vcs_repo": {},
+  "working_directory": "",
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/prevent-auto-apply-in-production/pass-prefix.json
+{
+  "mock": {
+    "tfrun": "mock-tfrun-pass-prefix.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}
+EOF
+
+cat <<-'EOF' > /root/sentinel/test/prevent-auto-apply-in-production/pass-suffix.json
+{
+  "mock": {
+    "tfrun": "mock-tfrun-pass-suffix.sentinel"
+  },
+  "test": {
+    "main": true
+  }
+}
+EOF
+
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/extra-credit/solve-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/extra-credit/solve-sentinel
@@ -1,0 +1,18 @@
+#!/bin/bash -l
+
+# Enable bash history
+HISTFILE=/root/.bash_history
+set -o history
+
+cd /root/sentinel
+
+# Edit the prevent-auto-apply-in-production.sentinel policy
+sed -i 's/<condition_1>/tfrun.workspace.name matches "^prod-(.*)"/g' prevent-auto-apply-in-production.sentinel
+sed -i 's/<condition_2>/tfrun.workspace.name matches "(.*)-prod$"/g' prevent-auto-apply-in-production.sentinel
+sed -i 's/<condition_3>/tfrun.workspace.auto_apply is true/g' prevent-auto-apply-in-production.sentinel
+sed -i 's/<expression_1>/tfrun.workspace.name/g' prevent-auto-apply-in-production.sentinel
+
+# Test the prevent-auto-apply-in-production.sentinel policy
+sentinel test -run=auto -verbose
+
+exit 0

--- a/instruqt-tracks/sentinel-for-terraform-v3/track.yml
+++ b/instruqt-tracks/sentinel-for-terraform-v3/track.yml
@@ -1,0 +1,780 @@
+slug: sentinel-for-terraform-v3
+id: c9h6uckgsy9u
+type: track
+title: Sentinel for Terraform (v3)
+teaser: |
+  Learn how to write and test Sentinel policies for Terraform.
+description: |-
+  [Sentinel](https://docs.hashicorp.com/sentinel) allows customers to implement policy-as-code in the same way that Terraform implements infrastructure-as-code.
+
+  Governance and security teams can write Sentinel policies to restrict what can be provisioned in Terraform Cloud and Terraform Enterprise workspaces. Sentinel allows these teams to control costs and enforce security standards.
+
+  In this track, you will write and test policies that restrict resources, data sources, and modules provisioned by Terraform in AWS, Azure, and GCP. This version of the track uses the newer v2 versions of the tfplan, tfstate, and tfconfig Sentinel imports.  However, since these v2 imports can only be used with Terraform 0.12 and 0.13, if you are still using Terraform 0.11, we recommend you use the [v1 version](https://play.instruqt.com/hashicorp/tracks/sentinel-for-terraform-v1) of this track which uses the older v1 versions of those imports.
+
+  This track is intended for use with these PowerPoint [slides](https://storage.cloud.google.com/instruqt-hashicorp-tracks/sentinel-shared/Sentinel-for-Terraform-v3.pptx) which you should download.
+
+  You should first run the [Sentinel CLI Basics](https://play.instruqt.com/hashicorp/tracks/sentinel-cli-basics) track which introduces the Sentinel CLI.
+
+  We recommend starting this track when you can set aside at least 4 hours of uninterrupted time. If you find yourself running out of time or are interrupted, we recommend saving all your completed policies outside the track so that you can quickly restore them if forced to begin the track again.
+icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/terraform.png
+tags:
+- terraform
+- sentinel
+owner: hashicorp
+developers:
+- roger@hashicorp.com
+private: false
+published: true
+challenges:
+- slug: exercise-1
+  id: jlxuexs2iznt
+  type: challenge
+  title: Exercise 1
+  teaser: |
+    Restrict Vault authentication methods.
+  assignment: |-
+    ## Introduction
+    In this challenge, you will write your first Sentinel policy for Terraform.
+
+    Your task is to complete and test a Sentinel policy that restricts the Vault authentication methods (backends) provisioned by the `vault_auth_backend` resource of Terraform's Vault Provider to the following choices: Azure, Kubernetes, GitHub, and AppRole.
+
+    We've made things easier by writing most of the policy for you and by providing the test cases and mocks that you need to test it. The policy uses the "find_resources" and "filter_attribute_not_in_list" functions from the "tfplan-functions.sentinel" module in the /root/sentinel/common-functions/tfplan-functions directory. This module was copied from [tfplan-functions.sentinel](https://github.com/hashicorp/terraform-guides/blob/master/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel).
+
+    Note that the import statement uses the alias `plan` for the "tfplan-functions" import to keep lines that use it shorter. This also makes it clear which file the module is derived from.
+
+    At this point, we recommend you look at the tree diagram in the [Import Overview](https://www.terraform.io/docs/cloud/sentinel/import/tfplan-v2.html#import-overview) for the `tfplan/v2` import that these functions use.
+
+    Terraform and Sentinel documentation often refer to the `attributes` of resources and data sources, but these include two different things:
+      * The `arguments` which are the inputs to the resources and data sources and are specified in Terraform code.
+      * The `exported attributes` which cannot be set in the Terraform code but are instead returned by the providers that provision the resources or read the data sources.
+
+    When you search a Terraform resource or data source document for "attributes" to restrict, you will mostly be interested in its "arguments".
+
+    When referring to an attribute in the `tfplan/v2` import, you have to use the attribute's key in the `after` map of the `change` collection of a resource or data source contained in the `resource_changes` collection. In other words, a policy evaluating attribute "x" with the `tfplan/v2` import ultimately ends up using an expression like `rc.change.after.x`.
+
+    In this example, `rc` is an iterator variable defined in a `for` loop or in a `filter` or `all` expression that iterates over a collection of resources. Actual code will often use a different variable. The common functions used in this track and in the hashicorp/terraform-guides repository hide a lot of this from you, but it is good to understand what they are doing under the covers.
+
+    At any point while solving the challenge, you can click the green "Check" button to get a hint suggesting something that you still need to do.
+
+    ## Complete the Policy
+    Open the "restrict-vault-auth-methods.sentinel" policy on the "Policies" tab. You'll see several placeholders in angular brackets throughout the policy. You need to replace those placeholders with suitable Sentinel expressions. In this and the remaining challenges, please do **not** edit the mock files; that would be cheating!
+
+    Replace `<method1>`, `<method2>`, `<method3>`, and `<method4>` in the `allowed_methods` list with suitable values. If you did not read the second screen while this challenge was loading, we suggest you read it now by clicking on the note icon in the upper right corner and then clicking the right arrow icon. Click the X icon to return to this challenge. Be sure to check the Vault auth method pages to see what the correct values are and note that case matters.
+
+    Next, you need to replace `<resource_type>` in the call to the "find_resources" method. We've already told you the resource type above.
+
+    Next, replace `<attribute>` and `<list>` in the call to the "filter_attribute_not_in_list" function. You can figure out the attribute you want to restrict by reading the [auth_backend](https://www.terraform.io/docs/providers/vault/r/auth_backend.html) documentation. The name of the list to use should be obvious.
+
+    After making all the substitutions, save the "restrict-vault-auth-methods.sentinel" policy by clicking the disk icon above the file.
+
+    ## Examine the Test Cases and Mocks
+    Now open the test cases and mock files on the "Test Cases" tab. You'll see that the "fail.json" test case refers to the "tfplan-functions.sentinel" module and the "mock-tfplan-fail.sentinel" mock file and expects the main rule to return `false`. You'll also see that the "pass.json" test case refers to the same module and the "mock-tfplan-pass.sentinel" mock file and expects the main rule to return `true`.
+
+    The mock files are simplified versions of mocks generated from plans of Terraform Cloud runs done against Terraform code that used the Vault provider to create some auth methods. The key data that determines whether a test case will pass or fail is in the `after` stanza of the `change` stanza of resources under the `resource_changes` collection.
+
+    The "mock-tfplan-fail.sentinel" mock file creates instances of the Kubernetes, GitHub, and AWS auth methods; the first two are allowed, but the third is not. The "mock-tfplan-pass.sentinel" mock file creates instances of the Kubernetes, GitHub, and Azure auth methods, all of which are allowed.
+
+    ## Test the Policy
+    Finally, test your policy on the "Sentinel CLI" tab:
+    ```
+    sentinel test -run=vault -verbose
+    ```
+    Both test cases should pass with green output. Additionally, the "fail.json" test case should print a violation message for the aws auth method.
+
+    If both test cases did not pass, or if Sentinel reported errors for specific lines of the policy, fix your policy and try testing it again until both test cases do pass.
+  notes:
+  - type: text
+    contents: |-
+      [Sentinel](https://docs.hashicorp.com/sentinel) allows customers to implement policy-as-code in the same way that Terraform implements infrastructure-as-code.
+
+      The Sentinel Command Line Interface (CLI) allows you to apply and test Sentinel policies including those that use mocks generated from Terraform Cloud and Terraform Enterprise plans.
+
+      You should run the [Sentinel CLI Basics](https://play.instruqt.com/hashicorp/tracks/sentinel-cli-basics) track before starting this track.
+  - type: text
+    contents: |-
+      We've launched the Sentinel CLI 0.15.2 on a Ubuntu VM running in GCP so that you don't need to download or install it.
+
+      In this track, you will complete and test policies that have been mostly written for you but have placeholders in angular brackets that you must replace with suitable Sentinel code. When doing this, do not keep the angular brackets, but do keep any quotes that might surround them.
+  - type: text
+    contents: |-
+      Please be sure to review all the notes screens (like this one) before each challenge and to open the key links in them in browser tabs outside of the Instruqt UI.
+
+      The information in the notes and their links will help you solve the challenges. We're intentionally giving you links instead of the actual information to simulate what you will have to do in the real world.
+
+      When someone asks you to write a Sentinel policy that makes sure all S3 buckets are encrypted, they probably won't tell you which Terraform resource provisions an S3 bucket or which of its attributes (arguments or exported attributes) determine its encryption. You're going to have to figure these things out on your own by searching for and reading relevant documentation.
+  - type: text
+    contents: |-
+      In this challenge, you will write your first Sentinel policy for Terraform.
+
+      We recommend reviewing slides 61-69, 77-83, and 84-89 of the Sentinel-for-Terraform-v2.pptx presentation at this point.
+
+      We've made things easier by writing most of the policy for you and by providing the test cases and mocks that you need to test it after you complete it.
+  - type: text
+    contents: |-
+      Your task is to complete and test a Sentinel policy that restricts the Vault authentication methods (backends) provisioned by Terraform's Vault Provider.
+
+      Don't worry if you don't know much about Vault. You'll find what you need in these URLs:
+      https://www.terraform.io/docs/providers/vault/r/auth_backend.html
+      https://www.vaultproject.io/docs/auth/index.html
+
+      If you look at the links for various Vault auth methods under the second of these links, you'll see that the `vault auth enable` command always specifies the auth method type with a single lower-case string identical to or similar to the full name of the auth method. These strings are also what the Terraform Vault Provider uses when creating Vault auth methods.
+  tabs:
+  - title: Policies
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/
+  - title: Test Cases
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/test/restrict-vault-auth-methods/
+  - title: Sentinel CLI
+    type: terminal
+    hostname: sentinel
+  difficulty: basic
+  timelimit: 3600
+- slug: exercise-2a
+  id: kbpjp1jbagmm
+  type: challenge
+  title: Exercise 2a
+  teaser: |
+    Restrict AWS IAM access keys (first version).
+  assignment: |-
+    ## Introduction
+    In this challenge and the next, you will write a second Sentinel policy for Terraform.
+
+    Your task is to complete and test a Sentinel policy that requires that all AWS IAM access keys provisioned by Terraform's AWS Provider include a PGP key that starts with "keybase:". This means that a specific attribute on a specific resource of that provider must start with "keybase:".
+
+    You'll complete a simple version of the policy in this challenge and then complete a more complex version in the next challenge.
+
+    We've made things easier by writing most of the policy for you (in two versions) and by providing the test cases and mocks that you need to test it.
+
+    At any point while solving the challenge, you can click the green "Check" button to get a hint suggesting something that you still need to do.
+
+    ## Complete the First Version
+    On the "Policies" tab, you'll see that there is new policy called "require-access-keys-use-pgp-a.sentinel". Open the policy. You'll see several placeholders in angular brackets throughout the policy. You need to replace those placeholders with suitable Sentinel expressions.
+
+    Replace `<resource_type>` in the call to the `find_resources` function in the "require-access-keys-use-pgp-a.sentinel" policy with a suitable resource type from the AWS provider. If you did not read the second screen while this challenge was loading, we suggest you read it now by clicking on the note icon in the upper right corner and then clicking the right arrow icon. Click the X icon to return to the challenge.
+
+    Now that you have found the documentation page for the resource you are restricting, you can determine the specific attribute that is used to set a PGP key on an AWS IAM access key. Replace `<attribute>` with that attribute in the call to the "filter_attribute_does_not_have_prefix" function in the "require-access-keys-use-pgp-a.sentinel" policy.
+
+    The "filter_attribute_does_not_have_prefix" function in the "tfplan-functions.sentinel" module does the following things:
+      * Iterates over all resources in the list passed to it.
+      * Calls the `evaluate_attribute` function to evaluate the value of the specified attribute for the current resource and uses the `else null` expression to convert the `undefined` value into `null` to cover the case that the resource did not have the attribute defined.
+      * Checks if the value is `null`.
+      * Uses the boolean expression `not strings.has_prefix(v, prefix)` to determine if the attribute does not start with the prefix (which in our case is "keybase:").
+      * Adds violating resources to the `violators` map and corresponding violation messages to the `messages` map.
+      * If `prtmsg` is `true`, prints warning messages for violators.
+      * Returns a map with the `violators` and `messages` maps and their common length.
+
+    Understanding this code will help you complete the "require-access-keys-use-pgp-b.sentinel" policy in the next challenge after you successfully complete and test the "require-access-keys-use-pgp-a.sentinel" policy.
+
+    You now need to replace `<condition>` in the `main` rule of the "require-access-keys-use-pgp-a.sentinel" policy with a condition that will make the rule return `true` when there are no violations. You have already seen the condition in the slides and in exercise 1. Be sure to save the "require-access-keys-use-pgp-a.sentinel" policy.
+
+    ## Examine the Test Cases and Mocks
+    Open the test cases and mock files on the "Test Cases" tab. You'll see that we've actually included 3 fail test cases with 3 corresponding mock files. Using multiple fail test cases allows us to test multiple ways in which a policy could fail. In this case, we're testing the attribute of interest to see if it is `null`, missing, or has an invalid value that does not start with "keybase:". All 3 fail test cases expect the main rule to return `false`. Of course, we've also included a pass test case and a corresponding mock file that does include the desired attribute with an allowed value. The pass test case expects the main rule to return `true`.
+
+    The mock files are simplified versions of mocks generated from plans of Terraform Cloud runs done against Terraform code that used the AWS provider to create an AWS IAM access key.
+
+    ## Test the First Version
+    Now, you should test your policy with this command on the "Sentinel CLI" tab:
+    ```
+    sentinel test -run=pgp-a.sentinel -verbose
+    ```
+    Setting the `-run` argument to "pgp-a.sentinel" will only match the desired policy and avoid running any other policies. All 4 test cases should pass with green output. Additionally, the 3 fail test cases should print violation messages.
+
+    If that is not the case, you will need to edit the "require-access-keys-use-pgp-a.sentinel" policy and test the policy again until all 4 test cases pass.
+
+    In the next challenge, you'll complete a more complex version of the policy.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will write the first version of a second Sentinel policy for Terraform.
+
+      We recommend reviewing slides 31, 34-39, 42, and 90-91 of the Sentinel-for-Terraform-v2.pptx presentation at this point. Pay special attention to the descriptions of Sentinel's [for](https://docs.hashicorp.com/sentinel/language/loops/) loop, [if/else](https://docs.hashicorp.com/sentinel/language/conditionals/) conditional, [else](https://docs.hashicorp.com/sentinel/language/spec/#else-operator) operator, and [strings](https://docs.hashicorp.com/sentinel/imports/strings) import. You'll use all of these in the second version of the policy you write.
+
+      We've made things easier by writing most of the policy for you and by providing the test cases and mocks that you need to test it.
+  - type: text
+    contents: |-
+      Your task is to complete and test a Sentinel policy that requires that all AWS IAM access keys provisioned by Terraform's AWS Provider include a PGP key.
+
+      Don't worry if you don't know much about AWS. You can find the information you need in this URL: https://www.terraform.io/docs/providers/aws/index.html
+
+      You can use the filter link at the top of the left-hand menu on that page to search for resources that have "access". There is only one good match that also has "key". Click on it to see what attributes are available for it.
+
+      You'll also find the documentation for the [strings](https://docs.hashicorp.com/sentinel/imports/strings) import useful.
+  tabs:
+  - title: Policies
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/
+  - title: Test Cases
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/test/require-access-keys-use-pgp-a/
+  - title: Sentinel CLI
+    type: terminal
+    hostname: sentinel
+  difficulty: basic
+  timelimit: 1800
+- slug: exercise-2b
+  id: 0vnfboalcoaf
+  type: challenge
+  title: Exercise 2b
+  teaser: |
+    Restrict AWS IAM access keys (second version).
+  assignment: |-
+    ## Introduction
+    In this challenge, you will write a second version of a second Sentinel policy for Terraform.
+
+    We've made things easier by writing most of the policy for you and by providing the test cases and mocks that you need to test it.
+
+    At any point while solving the challenge, you can click the green "Check" button to get a hint suggesting something that you still need to do.
+
+    ## Complete the Second Version
+    Completing the "require-access-keys-use-pgp-a.sentinel" policy should have been fairly easy since it had the same structure as the "restrict-ec2-instance-type.sentinel" and "restrict-vault-auth-methods.sentinel" policies. Almost all the exercises in this track could be solved with short policies that call functions that we have already defined. However, if you only called those functions, you would not learn how to write similar functions yourself.
+
+    So, we would like you to pretend that the generic "filter_attribute_does_not_have_prefix" function did not exist and write your own Sentinel code to handle the specific needs of the exercise. Accordingly, please open the "require-access-keys-use-pgp-b.sentinel" policy and observe that it also has several placeholders in angular brackets that need to be replaced.
+
+    First, in the assignment of the `pgp_key` variable, replace `<expression>` with Sentinel code that will convert `key.change.after.pgp_key` to `null` if it is missing.
+
+    Then replace `<condition_1>` with a condition that tests if the `pgp_key` attribute was missing. This condition should use the `pgp_key` variable.
+
+    Next, replace `<condition_2>` with a condition that tests if the `pgp_key` variable does **not** start with "keybase:". While there are several ways of doing this, please use the "strings" import which is also used in the "filter_attribute_does_not_have_prefix" function that was used by the "require-access-keys-use-pgp-a.sentinel" policy.
+
+    Note that this version of the policy sets `violations` to `length(violatingIAMAccessKeys)` instead of `violatingIAMAccessKeys["length"]` since `violatingIAMAccessKeys` is just a regular map without a key called `length` as had been the case when it was returned by the filter function.
+
+    After making all of the above substitutions, save the "require-access-keys-use-pgp-b.sentinel" policy.
+
+    ## Test the Second Version
+    Finally, test your policy:
+    ```
+    sentinel test -run=pgp-b.sentinel -verbose
+    ```
+    All 4 test cases should pass with green output. Additionally, the 3 fail test cases should print violation messages.
+
+    If that is not the case, you will need to edit the "require-access-keys-use-pgp-b.sentinel" policy and test the policy again until all 4 test cases pass.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will write a second version of the second Sentinel policy for Terraform.
+
+      We've made things easier by writing most of the policy for you and by providing the test cases and mocks that you need to test it.
+
+      Your task is to complete and test a Sentinel policy that requires that all AWS IAM access keys provisioned by Terraform's AWS Provider include a PGP key.
+  tabs:
+  - title: Policies
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/
+  - title: Test Cases
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/test/require-access-keys-use-pgp-b/
+  - title: Sentinel CLI
+    type: terminal
+    hostname: sentinel
+  difficulty: basic
+  timelimit: 1800
+- slug: exercise-3a
+  id: r8xoedtzzqqy
+  type: challenge
+  title: Exercise 3a
+  teaser: |
+    Restrict domains of AWS Certificate Manager (ACM) Certificates (first version).
+  assignment: |-
+    ## Introduction
+    In this challenge, you will write a third Sentinel policy for Terraform.
+
+    Your task is to complete and test a Sentinel policy that requires that all AWS Certificate Manager (ACM) Certificates referenced by a data source in Terraform's AWS Provider have domains that are subdomains of "hashidemos.io".
+
+    You'll complete a simple version of the policy in this challenge and then complete a more complex version in the next challenge.
+
+    We've made things easier by writing most of the policy for you (in two versions) and by providing the test cases and mocks that you need to test it. The policy uses the "find_datasources" function from the "tfstate-functions.sentinel" module in the /root/sentinel/common-functions/tfstate-functions directory. This module was copied from [tfstate-functions.sentinel](https://github.com/hashicorp/terraform-guides/blob/master/governance/third-generation/common-functions/tfstate-functions/tfstate-functions.sentinel).
+
+    Note that the import statement uses the alias `state` for the "tfstate-functions" import to keep lines that use it shorter. This also makes it clear which file the module is derived from.
+
+    At this point, we recommend you look at the tree diagram in the [Import Overview](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html#import-overview) for the `tfstate/v2` import.
+
+    When referring to an attribute in the `tfstate/v2` import, you have to use the attribute's key in the `values` map of a resource or data source contained in the import's `resources` collection. So, a policy evaluating attribute "x" with the `tfstate/v2` import ultimately ends up using an expression like `r.values.x`. (Recall that the `tfplan/v2` import uses an expression like `rc.change.after.x`.)
+
+    In this example, `r` is an iterator variable defined in a `for` loop or in a `filter` or `all` expression that iterates over a collection of resources. Actual code will often use a different variable. Of course, the common functions used in this track and in the hashicorp/terraform-guides repository hide a lot of this from you, but it is good to understand what they are doing under the covers.
+
+    At any point while solving the challenge, you can click the green "Check" button to get a hint suggesting something that you still need to do.
+
+    ## Complete the First Version
+    Open the "restrict-acm-certificate-domains-a.sentinel" policy on the "Policies" tab.
+
+    You'll see several placeholders in angular brackets throughout the policy. You need to replace those placeholders with suitable Sentinel expressions.
+
+    Replace `<data_source_type>` in the call made to the `find_datasources` function in the "restrict-acm-certificate-domains-a.sentinel" policy with a suitable data source type from the AWS provider. If you did not read the second screen while this challenge was loading, we suggest you read it now by clicking on the note icon in the upper right corner and then clicking the right arrow icon. Click the X icon to return to the challenge.
+
+    Now that you have found the documentation page for the data source you are restricting, you can determine the specific attribute that is used to set the domain on an ACM certificate. Please replace `<attribute>` in the "restrict-acm-certificate-domains-a.sentinel" policy with that attribute.
+
+    You next need to replace `<expression>` with a suitable expression representing the value of the domain. By this point, the right expression should already be in your policy.
+
+    ## Examine the Test Cases and Mocks
+    Now open the test cases and mock files on the "Test Cases" tab. You'll see that the "fail.json" test case refers to the "tfstate-functions.sentinel" module and the "mock-tfstate-fail.sentinel" mock file and expects the main rule to return `false`. You'll also see that the "pass.json" test case refers to the same module and the "mock-tfstate-pass.sentinel" mock file and expects the main rule to return `true`.
+
+    The mock files are simplified versions of mocks generated from plans of Terraform Cloud runs done against Terraform code that used the AWS provider to retrieve information from two AWS ACM certificates.
+
+    ## Test the First Version
+    Now, you should test your policy on the "Sentinel CLI" tab with this command:
+    ```
+    sentinel test -run=domains-a.sentinel -verbose
+    ```
+    Setting the `-run` argument to "domains-a.sentinel" will only match the desired policy and avoid running other policies. Both test cases should pass with green output. Additionally, they will both print messages indicating whether domains were valid or not.
+
+    If that is not the case, you will need to edit the "restrict-acm-certificate-domains-a.sentinel" policy and test the policy again until both test cases pass.
+
+    In the next challenge, you will complete a more complex version of the same policy.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will write a third Sentinel policy for Terraform.
+
+      We recommend reviewing slides 102-105, 33, and 38 of the Sentinel-for-Terraform-v2.pptx presentation. In this exercise, you will use the [tfstate/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfstate-v2.html) import, the [filter](https://docs.hashicorp.com/sentinel/language/collection-operations/#filter-expression) expression, and the [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator.
+
+      We've made things easier by writing most of the policy for you (in two versions) and by providing the test cases and mocks that you need to test it.
+  - type: text
+    contents: |-
+      Your task is to complete and test a Sentinel policy that requires that all AWS Certificate Manager (ACM) Certificates referenced by a data source in Terraform's AWS Provider have domains that are subdomains of "hashidemos.io". (This means the domains must end in ".hashidemos.io".)
+
+      As in Exercise 2, you can look at the [AWS Provider](https://www.terraform.io/docs/providers/aws/index.html) documentation to search for the relevant data source.
+
+      You can use the filter link at the top of the left-hand menu on that page to search for a data source that has "acm". Click on it to see what attributes are available for it.
+
+      You might also find the documentation for the Sentinel [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator useful.
+  tabs:
+  - title: Policies
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/
+  - title: Test Cases
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/test/restrict-acm-certificate-domains-a/
+  - title: Sentinel CLI
+    type: terminal
+    hostname: sentinel
+  difficulty: basic
+  timelimit: 1800
+- slug: exercise-3b
+  id: zimhkwdx4ehq
+  type: challenge
+  title: Exercise 3b
+  teaser: |
+    Restrict domains of AWS Certificate Manager (ACM) Certificates (second version).
+  assignment: |-
+    ## Introduction
+    In this challenge, you will write a second version of the third Sentinel policy for Terraform.
+
+    The policy will require that all AWS Certificate Manager (ACM) Certificates referenced by a data source in Terraform's AWS Provider have domains that are subdomains of "hashidemos.io".
+
+    At any point while solving the challenge, you can click the green "Check" button to get a hint suggesting something that you still need to do.
+
+    ## Complete the Second Version
+    The second version of the policy uses an embedded function, `validate_certs`, to validate that evaluated ACM certs meet the desired conditions. Accordingly, please open the "restrict-acm-certificate-domains-b.sentinel" policy and observe that it also has several placeholders in angular brackets that need to be replaced.
+
+    Note that the `validate_certs` function uses a different approach than was used in exercises 1 and 2. Instead of creating a list of resources that violate some condtion, it uses a boolean variable, `validated`, that is initially set to `true`, iterates over all resources passed to it, and sets `validated` to `false` if there are any violations. It returns the value of the `validated` variable. The main rule of the policy then checks whether it returns `true` or `false`.
+
+    Open the "restrict-acm-certificate-domains-b.sentinel" policy on the "Policies" tab.
+
+    Start your modifications by replacing `<expression>` with an expression that will assign the value of the current certificate's domain to the `domain` variable. If you're unsure what to use, look at your completed "restrict-acm-certificate-domains-a.sentinel" policy.
+
+    You now need to replace `<condition>` in the definition of the `validate_certs` function with a condition that checks that the domain of the ACM certificate set in the `domain` variable is a subdomain of the `parent_domain` argument of the function. We would like you to use the [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator.
+
+    Now that you've completed the `validate_certs` function, you need to call it, replacing `<regex>` with a regular expression that ensures that the domains of the ACM certificates contained in the `allACMCerts` list end in ".hashidemos.io".
+
+    After making all the above substitutions, be sure to save the restrict-acm-certificate-domains-b.sentinel policy.
+
+    ## Test the Second Version
+    Finally, test your policy on the "Sentinel CLI" tab with this command:
+    ```
+    sentinel test -run=domains-b.sentinel -verbose
+    ```
+
+    Both test cases should pass with green output. Additionally, they will both print messages indicating whether domains were valid or not.
+
+    If that is not the case, you will need to edit the "restrict-acm-certificate-domains-b.sentinel" policy and test the policy again until both test cases pass.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will write a second version of the third Sentinel policy for Terraform.
+
+      We've made things easier by writing most of the policy for you and by providing the test cases and mocks that you need to test it.
+
+      Your task is to complete and test a Sentinel policy that requires that all AWS Certificate Manager (ACM) Certificates referenced by a data source in Terraform's AWS Provider have domains that are subdomains of "hashidemos.io". (This means the domains must end in ".hashidemos.io".)
+  tabs:
+  - title: Policies
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/
+  - title: Test Cases
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/test/restrict-acm-certificate-domains-b/
+  - title: Sentinel CLI
+    type: terminal
+    hostname: sentinel
+  difficulty: basic
+  timelimit: 1800
+- slug: exercise-4a
+  id: wvxmgejuyhef
+  type: challenge
+  title: Exercise 4a
+  teaser: |
+    Restrict images used by Google Cloud Platform compute instances (first version).
+  assignment: |-
+    ## Introduction
+    In this challenge, you will write a fourth Sentinel policy for Terraform.
+
+    Your task is to complete and test a Sentinel policy that requires Google Cloud Platform (GCP) compute instances provisioned by Terraform's Google Provider to use the public image "debian-cloud/debian-9". In a real-world policy, you would allow multiple images, but we wanted to keep things simple for this exercise.
+
+    You'll complete a simple version of the policy in this challenge and then complete a more complex version in the next challenge.
+
+    We've made things easier by writing most of the policy for you (in two versions) and by providing the test cases and mocks that you need to test it. The policy uses the "find_resources" function from the "tfplan-functions.sentinel" module in the /root/sentinel/common-functions/tfplan-functions directory.
+
+    At any point while solving the challenge, you can click the green "Check" button to get a hint suggesting something that you still need to do.
+
+    ## Complete the First Version
+    Open the "restrict-gcp-instance-image-a.sentinel" policy on the "Policies" tab. You'll see several placeholders in angular brackets throughout the policy. You need to replace those placeholders with suitable Sentinel expressions.
+
+    Replace `<resource_type>` in the call to the `find_resources` function with the correct resource type from the Google provider.
+
+    Now that you have found the documentation page for the resource you are restricting, you can determine the specific attribute that is used to set the image on a Google compute instance. This attribute is nested inside one block which is itself contained in a second block. Each of these blocks can only occur once.
+
+    In Sentinel, a block is treated as a list of maps. Additionally, lists are indexed starting with 0. We would use the expression, `x[0].y[0].z`, to refer directly to the attribute `z` of the first map inside the `y` block of the first map inside the `x` block of a resource. However, the `evaluate_attribute` function called by the `filter_attribute_is_not_value` function expects an expression like `x[0].y[0].z` to be given as `x.0.y.0.z`.
+
+    You now need to replace `<expression_1>` in the "restrict-gcp-instance-image-a.sentinel" policy with a reference to the attribute that represents the image of a Google compute instance. Use an expression like the final one given in the last paragraph.
+
+    Next, you need to replace `<expression_2>` in the "restrict-gcp-instance-image-a.sentinel" policy with an expression that gives the number of GCP compute instances with violations. This expression will be similar to expressions that have been assigned to the `violations` variable in earlier exercises.
+
+    ## Examine the Test Cases and Mocks
+    Now open the test cases and mock files on the "Test Cases" tab. You'll see that the test cases, "fail-invalid-image.json" and "fail-no-initialize-params.json", refer to the "mock-tfplan-fail-invalid-image.sentinel" and "mock-tfplan-fail-no-initialize-params.sentinel" mock files respectively and expect the main rule to return `false`. You'll also see that the test case, "pass.json", refers to the "mock-tfplan-pass.sentinel" mock file and expects the main rule to return `true`. All 3 test cases also refer to the "tfplan-functions.sentinel" module.
+
+    The mock files are simplified versions of mocks generated from plans of Terraform Cloud runs done against Terraform code that used the Google provider to create a GCE compute instance. The "mock-tfplan-fail-no-initialize-params.sentinel" mock file was generated from a Terraform configuration that first generated a GCE compute disk and then created a GCE compute instance from it, avoiding the need to use the `initialize_params` block of the compute instance resource. The other two mocks created the compute instance resource directly from standard images.
+
+    ## Test the First Version
+    Now, you should test your policy on the "Sentinel CLI" tab with this command:
+    ```
+    sentinel test -run=image-a.sentinel -verbose
+    ```
+    Setting the `-run` argument to "image-a.sentinel" will only match the desired policy and avoid running other policies. All 3 test cases should pass with green output. Additionally, the fail tests will print messages indicating that an image was either not defined or not allowed.
+
+    If that is not the case, you will need to edit the "restrict-gcp-instance-image-a.sentinel" policy and test the policy again until all 3 test cases pass.
+
+    In the next challenge, you will complete a second version of this policy.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will write a fourth Sentinel policy for Terraform.
+
+      We recommend reviewing slides 106-110 of the Sentinel-for-Terraform-v2.pptx presentation. In this exercise, you will learn how to evaluate an attribute that is contained in a block contained in another block of a resource. A block is treated by Sentinel as a list of maps.
+
+      We've made things easier by writing most of the policy for you (in two versions) and by providing the test cases and mocks that you need to test it.
+  - type: text
+    contents: |-
+      Your task is to complete and test a Sentinel policy that requires Google Cloud Platform (GCP) compute instances provisioned by Terraform's Google Provider to use the public image "debian-cloud/debian-9".
+
+      Don't worry if you don't know much about GCP. You can look at the [Google Provider](https://www.terraform.io/docs/providers/google/index.html) documentation to find the relevant GCP resource. (Be sure to pick a resource and not a data source with the same name.)
+
+      You might also find the documentation for Sentinel [lists](https://docs.hashicorp.com/sentinel/language/lists), [maps](https://docs.hashicorp.com/sentinel/language/maps), and the standard [types](https://docs.hashicorp.com/sentinel/imports/types) import useful.
+  tabs:
+  - title: Policies
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/
+  - title: Test Cases
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/test/restrict-gcp-instance-image-a/
+  - title: Sentinel CLI
+    type: terminal
+    hostname: sentinel
+  difficulty: basic
+  timelimit: 1800
+- slug: exercise-4b
+  id: 5xp14zhwzspf
+  type: challenge
+  title: Exercise 4b
+  teaser: |
+    Restrict images used by Google Cloud Platform compute instances (second version).
+  assignment: |-
+    ## Introduction
+    In this challenge, you will write a second version of the fourth Sentinel policy for Terraform.
+
+    Your task is to complete and test a Sentinel policy that requires Google Cloud Platform (GCP) compute instances provisioned by Terraform's Google Provider to use the public image "debian-cloud/debian-9". In a real-world policy, you would allow multiple images, but we wanted to keep things simple for this exercise.
+
+    At any point while solving the challenge, you can click the green "Check" button to get a hint suggesting something that you still need to do.
+
+    ## Complete the Second Version
+    The second version of the policy uses an embedded function, `filter_images`, to validate that evaluated GCP compute instances meet the desired conditions.
+
+    Accordingly, please open the "restrict-gcp-instance-image-b.sentinel" policy and observe that it also has several placeholders in angular brackets that need to be replaced.
+
+    First, replace `<expression_1>` in the line that assigns a value to the `boot_disk` variable with an expression that gives the data of the `boot_disk` block of the "google_compute_instance" resource. For a hint about the structure of your replacement, see line 19 of the "require-access-keys-use-pgp-b.sentinel" policy on the "Policies" tab, but don't bother adding `else null` to your expression.
+
+    We use the `types` import to check if `<expression_2>` is a list since we will try to access elements of it in the `else` statement and would get an error if it is not a list (which would be the case if it were missing or `null`). We did not need to check the type of the `boot_disk` block because it is a required block of the resource and therefore cannot be missing.
+
+    So, please replace `<expression_2>` with an expression that gives the data of the `initialize_params` block of the first map of the `boot_disk` block.  Use the `[n].` notation rather than the `.n.` notation that the `evaluate_attribute` function requires.
+
+    You now need to replace two occurences of `<expression_3>` in the `filter_images` function with a complex expression that refers to the value of the image set in the first `initialize_params` block of the first `boot_disk` block. In addition to specifying the correct attribute of the `initialize_params` block, keep in mind that it needs to be indexed just like `boot_disk` block was indexed. Your replacement for `<expression_3>` should start with what you used when replacing `<expression_2>`.
+
+    Finally, you need to replace `<add_main_rule>` with a main rule that evaluates the number of GCP compute instances that had violations. This will look very similar to the main rule in your other policies.
+
+    After making all the above substitutions, save the restrict-gcp-instance-image-b.sentinel policy.
+
+    ## Test the Second Version
+    Finally, test your policy on the "Sentinel CLI" tab with this command:
+    ```
+    sentinel test -run=image-b.sentinel -verbose
+    ```
+
+    All 3 test cases should pass with green output. Additionally, the fail test cases will print messages indicating that the image was not defined or invalid.
+
+    If that is not the case, you will need to edit the "restrict-gcp-instance-image-b.sentinel" policy and test the policy again until all 3 test cases pass.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will write a second version of the fourth Sentinel policy for Terraform.
+
+      We've made things easier by writing most of the policy for you and by providing the test cases and mocks that you need to test it.
+
+      Your task is to complete and test a Sentinel policy that requires Google Cloud Platform (GCP) compute instances provisioned by Terraform's Google Provider to use the public image "debian-cloud/debian-9".
+  tabs:
+  - title: Policies
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/
+  - title: Test Cases
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/test/restrict-gcp-instance-image-b/
+  - title: Sentinel CLI
+    type: terminal
+    hostname: sentinel
+  difficulty: basic
+  timelimit: 1800
+- slug: exercise-5a
+  id: jkxykckoqz3m
+  type: challenge
+  title: Exercise 5a
+  teaser: |
+    Only allow modules from the Private Module Registry (first version).
+  assignment: |-
+    ## Introduction
+    In this challenge, you will write a fifth Sentinel policy for Terraform.
+
+    Your task is to complete and test a Sentinel policy that requires that all modules loaded by the root module come from the [Private Module Registry](https://www.terraform.io/docs/cloud/registry/index.html) (PMR) of a Terraform Cloud organization.
+
+    You'll complete a simple version of the policy in this challenge and then complete a more complex version in the next challenge.
+
+    We recommend reviewing this [doc](https://www.terraform.io/docs/cloud/registry/using.html) that describes how to specify the `source` for a module in a Private Module Registry on a Terraform Cloud or Terraform Enterprise server.
+
+    We've made things easier by writing most of the policy for you (in two versions) and by providing the test cases and mocks that you need to test it. The mocks simulate the use of two Azure modules.
+
+    At this point, we recommend you look at the tree diagram in the [Import Overview](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#import-overview) for the `tfconfig/v2` import that the policy uses.
+
+    At any point while solving the challenge, you can click the green "Check" button to get a hint suggesting something that you still need to do.
+
+    ## Complete the First Version
+    Open the "require-modules-from-pmr-a.sentinel" policy on the "Policies" tab. You'll see several placeholders in angular brackets throughout the policy. You need to replace those placeholders with suitable Sentinel expressions.
+
+    Note that this policy uses parameters like the "require-even-number.sentinel" policy did. While the `address` parameter has the default value `app.terraform.io`, the `organization` parameter does not have a default value. However, if you look at the "pass.json" and "fail.json" test case files on the "Test Cases" tab, you'll see that the value `Cloud-Operations` is assigned to the `organization` parameter in both of them.
+
+    Replace `<expression_1>` in the `require_modules_from_pmr` function with an expression that gives a list of all module calls. The `for` loop with that expression uses `index` and `mc` to represent the index and data for each of these module calls as it iterates across them. See the [module_calls](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html#the-module_calls-collection) section of the `tfconfig/v2` documentation for more details.
+
+    We only want the policy to restrict module calls made from the root module. While module calls generally have an index with the form `<module_address>:<name>`, the first part, `<module_address>:`, is ommitted for module calls made from the root module.
+
+    Accordingly, replace `<condition_1>` with a condition that requires the current module call to have an index that does not contain a colon. There are at least two ways of doing this with the [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator:
+
+      1. The simpler way uses `if index matches "<regex1>"` in which <regex1\> uses `.+` or `(.+)` twice to match one or more characters.
+      2. The slightly more complex way uses `if index matches "<regex2>"` in which <regex2\> contains a [negated character class](https://www.regular-expressions.info/charclass.html) and ensures that nothing in it occurs from the beginning (^) to the end ($) of the index.
+
+    Next, you need to replace `<condition_2>` with a condition that tests if the module call has a `source` from the desired Private Module Registry. Since this condition is placed after `not`, the function will print a violation message for modules that are not in the PMR and set the `validated` flag to `false`.
+
+    While you could use the `matches` operator in your replacement of `<condition_2>`, **please use the `has_prefix` function from Sentinel's [strings](https://docs.hashicorp.com/sentinel/imports/strings) import in your solution**.
+
+    In general, a well-designed function should not reference things defined outside of it. So, please do not reference the Sentinel parameters, `address` and `organization` from the top of the policy; instead, reference the function's arguments, `tf_address` and `tf_org`.
+
+    You can use Sentinel's `+` operator to concatenate variables and strings together. In fact, you'll see a useful example in the second violation message.
+
+    Next, you need to replace `<expression_2>` with an expression that gives the source of the module in the violation message.
+
+    Now that you've completed the `require_modules_from_pmr` function, you need to call it, replacing `<function>(<arg1>, <arg2>)` with a call to the function that passes in suitable arguments to it. The result is assigned to a boolean variable, `modules_from_pmr` which is evaluated by the `main` rule. This would be a good place to use the Sentinel parameters, `address` and `organization`, defined at the top of the policy. Also, you can concatentate variables and static strings with the `+` operator.
+
+    After making all the above substitutions, save the "require-modules-from-pmr-a.sentinel" policy by clicking the disk icon above the file.
+
+    ## Examine the Test Cases and Mocks
+    Now open the test cases and mock files on the "Test Cases" tab. You'll see that the "fail.json" test case refers to the "mock-tfconfig-fail.sentinel" mock file and expects the main rule to return false. You'll also see that the "pass.json" test case refers to the "mock-tfconfig-pass.sentinel" mock file and expects the main rule to return true.
+
+    As mentioned above, both test case files provide a value for the `organization` parameter. We also could have provided a value for the `address` parameter to override the default value set in the policy. We would do that if using a Terraform Enterprise server instead of the Terraform Cloud deployment hosted by HashiCorp.
+
+    The mock files are simplified versions of mocks generated from plans of Terraform Cloud runs done against Terraform code that used the Azure provider to provision Azure resources including resource groups, network resources, security group resources, and VMs. The "mock-tfconfig-fail.sentinel" mock uses modules from the public [Terraform Registry](https://registry.terraform.io/) while the "mock-tfconfig-pase.sentinel" mock uses modules from a PMR in the "Cloud-Operations" organization on the Terraform Cloud server ("app.terraform.io").
+
+    ## Test the First Version
+    Now, you should test your policy on the "Sentinel CLI" tab with this command:
+    ```
+    sentinel test -run=pmr-a.sentinel -verbose
+    ```
+    Setting the `-run` argument to "pmr.sentinel" will only match the desired policy and avoid running other policies. Both test cases should pass with green output. Additionally, the fail test case will print messages indicating that the root module of the Terraform configuration called modules that are not from the desired private module registry.
+
+    If that is not the case, you will need to edit the "require-modules-from-pmr-a.sentinel" policy and test the policy again until both test cases pass.
+
+    In the next challenge, you will complete a second version of the policy.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will write a fifth Sentinel policy for Terraform.
+
+      We recommend reviewing slides 111-115 of the Sentinel-for-Terraform-v2.pptx presentation.
+
+      We've made things easier by writing most of the policy for you (in two versions) and by providing the test cases and mocks that you need to test it. The mocks simulate the use of two Azure modules both from the public Terraform Registry and from a Private Module Registry in an organization on the Terraform Cloud server.
+  - type: text
+    contents: |-
+      Your task is to complete and test a Sentinel policy that requires that all modules called by the root module come from the [Private Module Registry](https://www.terraform.io/docs/cloud/registry/index.html) (PMR) of a Terraform Cloud organization called "Cloud-Operations". You will use the [tfconfig/v2](https://www.terraform.io/docs/cloud/sentinel/import/tfconfig-v2.html) import to do that.
+
+      Since the owners of a Terraform Cloud/Enterprise organization can prevent modules in their PMR from using external modules, requiring the root module to call all modules from the PMR effectively requires that all non-root modules come from the PMR.
+
+      You might find the documentation for Sentinel's [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator and [strings](https://docs.hashicorp.com/sentinel/imports/strings) import useful. You might also want to read about how modules are sourced from private module registries [here](https://www.terraform.io/docs/cloud/registry/using.html).
+  tabs:
+  - title: Policies
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/
+  - title: Test Cases
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/test/require-modules-from-pmr-a/
+  - title: Sentinel CLI
+    type: terminal
+    hostname: sentinel
+  difficulty: basic
+  timelimit: 1800
+- slug: exercise-5b
+  id: fx1mwkiag5bx
+  type: challenge
+  title: Exercise 5b
+  teaser: |
+    Only allow modules from the Private Module Registry (second version).
+  assignment: |-
+    ## Introduction
+    In this challenge, you will write a second version of the fifth Sentinel policy for Terraform.
+
+    Your task is to complete and test a Sentinel policy that requires that all modules loaded by the root module come from the [Private Module Registry](https://www.terraform.io/docs/cloud/registry/index.html) (PMR) of a Terraform Cloud organization.
+
+    At any point while solving the challenge, you can click the green "Check" button to get a hint suggesting something that you still need to do.
+
+    ## Complete the Second Version
+    In this challenge, we would like you to move your completed `require_modules_from_pmr` function into the file, "module-functions.sentinel", so that it can be called by other policies as a Sentinel module. We then want you to modify the "require-modules-from-pmr-b.sentinel" policy to call the function from that file.
+
+    Here are the steps you should follow:
+
+      1. Copy the entire `require_modules_from_pmr` function to the bottom of the "module-functions.sentinel" file that is in the /root/sentinel/common-functions/module-functions directory.
+      1. Save the "module-functions.sentinel" file.
+      1. Replace `<import_statement>` in the "require-modules-from-pmr-b.sentinel" policy with a suitable import statement that will allow that policy to call the function from the "module-functions.sentinel" file. We recommend that you look at the test cases to see the name they are using for the module that points at that file. **Please use the alias `modules`.**
+      1. Replace `<function_call>` with a call to the `require_modules_from_pmr` function in the module referenced by the import statement you just added. Be sure to include two suitable arguments in the function call.
+      1. Save the "require-modules-from-pmr-b.sentinel" policy.
+
+    ## Examine the Test Cases and Mocks
+    Now open the test cases and mock files on the "Test Cases" tab. These are like the ones in the previous challenge, but both test cases also refer to the "module-functions.sentinel" module that you just wrote.
+
+    ## Test the Second Version
+    Finally, test your policy on the "Sentinel CLI" tab with this command:
+    ```
+    sentinel test -run=pmr-b.sentinel -verbose
+    ```
+
+    Both test cases should pass with green output. Additionally, the fail test case will print messages indicating that the root module of the Terraform configuration called modules that are not from the desired private module registry.
+
+    If that is not the case, you will need to edit the "require-modules-from-pmr-b.sentinel" policy and test the policy again until both test cases pass.
+  notes:
+  - type: text
+    contents: |-
+      In this challenge, you will write a second version of the fifth Sentinel policy for Terraform.
+
+      We've made things easier by writing most of the policy for you and by providing the test cases and mocks that you need to test it. The mocks simulate the use of two Azure modules both from the public Terraform Registry and from a Private Module Registry in an organization on the Terraform Cloud server.
+
+      Your task is to complete and test a Sentinel policy that requires that all modules called by the root module come from the [Private Module Registry](https://www.terraform.io/docs/cloud/registry/index.html) (PMR) of a Terraform Cloud organization called "Cloud-Operations".
+  tabs:
+  - title: Policies
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/
+  - title: Test Cases
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/test/require-modules-from-pmr-b/
+  - title: Sentinel CLI
+    type: terminal
+    hostname: sentinel
+  difficulty: basic
+  timelimit: 1800
+- slug: extra-credit
+  id: i9ujmhos1z04
+  type: challenge
+  title: Extra Credit
+  teaser: |
+    Prevent auto apply on production workspaces.
+  assignment: |-
+    ## Introduction
+    In this extra credit challenge, you will use the [tfrun](https://www.terraform.io/docs/cloud/sentinel/import/tfrun.html) import to prevent production workspaces from having [Auto Apply](https://www.terraform.io/docs/cloud/workspaces/settings.html#auto-apply-and-manual-apply) enabled.
+
+    Your task is to complete and test a Sentinel policy that prevents any workspace with a name starting with "prod-" or ending in "-prod" from having the Auto Apply property set to `true`.
+
+    We've made things easier by writing most of the policy for you and by providing the test cases and mocks that you need to test it.
+
+    At any point while solving the challenge, you can click the green "Check" button to get a hint suggesting something that you still need to do.
+
+    ## Complete the Policy
+    Open the "prevent-auto-apply-in-production.sentinel" policy on the "Policies" tab. Note that it uses the `tfrun` import.
+
+    The first thing you need to do is replace `<condition_1>` and `<condition_2>` in the `validate_auto_apply` function with conditions that test if the workspace name starts with "prod-" or ends with "-prod". You will probably want to use Sentinel's [strings](https://docs.hashicorp.com/sentinel/imports/strings) import or [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator as you have done in earlier challenges. If you use the `strings` import, be sure to declare it at the top of the policy. If you use the `matches` operator, note that the comment at the top of the policy gives you regex expressions you can use with it.
+
+    Next, you need to replace `<condition_3>` with a condition that tests if the workspace has auto apply enabled. Review the [tfrun](https://www.terraform.io/docs/cloud/sentinel/import/tfrun.html) import's documentation to figure out what to use.
+
+    You should now replace `<expression_1>` in the `validate_auto_apply` function with an expression that gives the name of the workspace.
+
+    After making all the above substitutions, save the "prevent-auto-apply-in-production.sentinel" policy.
+
+    # Examine the Test Cases and Mocks
+    Please review the test cases and mock files on the "Test Cases" tab. You'll see that there are two fail test cases and two pass test cases with corresponding mocks. These give us fail and test cases for workspace names that start with "prod-" and end with "-prod".
+
+    ## Test the Policy
+    Finally, test your policy:
+    ```
+    sentinel test -run=auto -verbose
+    ```
+    All 4 test cases should pass with green output. Additionally, the fail test cases will print violation warnings.
+
+    If all 4 test cases did not pass, or if Sentinel reported errors for specific lines of the policy, fix your policy and try testing it again until all 4 test cases do pass.
+
+    Congratulations on completing the Sentinel in Terraform track! This is one of the more challenging workshop tracks.  Well done, if you were able to complete all the policies.  And kudos for trying even if you struggled a bit. Perhaps you can go through it a second time and do better?
+  notes:
+  - type: text
+    contents: |-
+      In this extra credit challenge, you will use the [tfrun](https://www.terraform.io/docs/cloud/sentinel/import/tfrun.html) import to prevent production workspaces from having [Auto Apply](https://www.terraform.io/docs/cloud/workspaces/settings.html#auto-apply-and-manual-apply) enabled.
+
+      We recommend reviewing slides 121-125 of the Sentinel-for-Terraform-v2.pptx presentation.
+
+      We've made things easier by writing most of the policy for you and by providing the test cases and mocks that you need to test it.
+  - type: text
+    contents: |-
+      Your task is to complete and test a Sentinel policy that prevents any workspace with a name starting with "prod-" or ending in "-prod" from having the Auto Apply property set to `true`.
+
+      You might find the documentation for Sentinel's [matches](https://docs.hashicorp.com/sentinel/language/spec/#matches-operator) operator and [strings](https://docs.hashicorp.com/sentinel/imports/strings) import useful.
+  tabs:
+  - title: Policies
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/
+  - title: Test Cases
+    type: code
+    hostname: sentinel
+    path: /root/sentinel/test/prevent-auto-apply-in-production/
+  - title: Sentinel CLI
+    type: terminal
+    hostname: sentinel
+  difficulty: basic
+  timelimit: 1800
+checksum: "11945258757610794086"


### PR DESCRIPTION
Added a v3 of the Sentinel for Terraform workshop that splits out each of exercises 2-5 into 2 separate challenges so that users no longer need to copy edited files to different name to match test directories.

This will avoid confusion and errors by students.