### PR TITLE
remove unneeded imports, update sentinel version

### DIFF
--- a/instruqt-tracks/sentinel-cli-basics/sentinel-cli/setup-sentinel
+++ b/instruqt-tracks/sentinel-cli-basics/sentinel-cli/setup-sentinel
@@ -6,7 +6,7 @@ mkdir -p /root/sentinel
 echo "cd /root/sentinel" >> /root/.profile
 
 # Install Sentinel
-SENTINEL_VERSION=0.15.2
+SENTINEL_VERSION=0.15.6
 wget https://releases.hashicorp.com/sentinel/${SENTINEL_VERSION}/sentinel_${SENTINEL_VERSION}_linux_amd64.zip
 unzip -d /bin sentinel_${SENTINEL_VERSION}_linux_amd64.zip
 rm sentinel_${SENTINEL_VERSION}_linux_amd64.zip

--- a/instruqt-tracks/sentinel-cli-basics/track.yml
+++ b/instruqt-tracks/sentinel-cli-basics/track.yml
@@ -20,6 +20,7 @@ developers:
 - roger@hashicorp.com
 private: false
 published: true
+show_timer: true
 challenges:
 - slug: sentinel-cli
   id: krvmyfhnkqkx
@@ -66,7 +67,7 @@ challenges:
       To learn more, see https://docs.hashicorp.com/sentinel.
   - type: text
     contents: |-
-      We've launched the Sentinel CLI 0.15.2 on a Ubuntu VM running in GCP so that you don't need to download or install it.
+      We've launched the Sentinel CLI 0.15.6 on a Ubuntu VM running in GCP so that you don't need to download or install it.
 
       After learning how to use the Sentinel CLI in the first challenge, you will run a very simple policy in the second challenge.
   tabs:
@@ -145,4 +146,4 @@ challenges:
     hostname: sentinel
   difficulty: basic
   timelimit: 2400
-checksum: "6005213471291559855"
+checksum: "540363501604633372"

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-1/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-1/setup-sentinel
@@ -6,7 +6,7 @@ mkdir -p /root/sentinel
 echo "cd /root/sentinel" >> /root/.profile
 
 # Install Sentinel
-SENTINEL_VERSION=0.15.2
+SENTINEL_VERSION=0.15.6
 wget https://releases.hashicorp.com/sentinel/${SENTINEL_VERSION}/sentinel_${SENTINEL_VERSION}_linux_amd64.zip
 unzip -d /bin sentinel_${SENTINEL_VERSION}_linux_amd64.zip
 rm sentinel_${SENTINEL_VERSION}_linux_amd64.zip
@@ -1500,9 +1500,6 @@ EOF
 # restrict-vault-auth-methods
 cat <<-'EOF' > /root/sentinel/restrict-vault-auth-methods.sentinel
 # This policy restricts which Vault auth methods can be created
-
-# Import the v2 tfplan import, but use the alias "tfplan"
-import "tfplan/v2" as tfplan
 
 # Import common-functions/tfplan-functions/tfplan-functions.sentinel
 # with alias "plan"

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-2a/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-2a/setup-sentinel
@@ -5,9 +5,6 @@ set -e
 cat <<-'EOF' > /root/sentinel/require-access-keys-use-pgp-a.sentinel
 # This policy requires AWS IAM access keys to use PGP keys
 
-# Import the v2 tfplan import, but use the alias "tfplan"
-import "tfplan/v2" as tfplan
-
 # Import common-functions/tfplan-functions/tfplan-functions.sentinel
 # with alias "plan"
 import "tfplan-functions" as plan

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-2b/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-2b/setup-sentinel
@@ -5,9 +5,6 @@ set -e
 cat <<-'EOF' > /root/sentinel/require-access-keys-use-pgp-b.sentinel
 # This policy requires AWS IAM access keys to use PGP keys
 
-# Import the v2 tfplan import, but use the alias "tfplan"
-import "tfplan/v2" as tfplan
-
 # Import common-functions/tfplan-functions/tfplan-functions.sentinel
 # with alias "plan"
 import "tfplan-functions" as plan
@@ -23,7 +20,7 @@ violatingIAMAccessKeys = {}
 for allIAMAccessKeys as address, key {
   # Set the pgp_key variable, but set to null if undefined
   pgp_key = key.change.after.pgp_key <expression>
-  # First, check if pgp_key is missing
+  # First, check if pgp_key is missing or null
   # Second, check if pgp_key does not start with "keybase:"
   # Add violators to violatingIAMAccessKeys and print warnings
   if <condition_1> {

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-3a/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-3a/setup-sentinel
@@ -6,9 +6,6 @@ cat <<-'EOF' > /root/sentinel/restrict-acm-certificate-domains-a.sentinel
 # This policy uses the tfstate import to restrict ACM certificates
 # to have domains that are sub-domains of hashidemos.io
 
-# Import the v2 tfstate import, but use the alias "tfstate"
-import "tfstate/v2" as tfstate
-
 # Import common-functions/tfstate-functions/tfstate-functions.sentinel
 # with alias "state"
 import "tfstate-functions" as state

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-3b/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-3b/setup-sentinel
@@ -6,9 +6,6 @@ cat <<-'EOF' > /root/sentinel/restrict-acm-certificate-domains-b.sentinel
 # This policy uses the tfstate import to restrict ACM certificates
 # to have domains that are sub-domains of hashidemos.io
 
-# Import the v2 tfstate import, but use the alias "tfstate"
-import "tfstate/v2" as tfstate
-
 # Import common-functions/tfstate-functions/tfstate-functions.sentinel
 # with alias "state"
 import "tfstate-functions" as state

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-4a/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-4a/setup-sentinel
@@ -5,9 +5,6 @@ set -e
 cat <<-'EOF' > /root/sentinel/restrict-gcp-instance-image-a.sentinel
 # This policy restricts the public images that GCP compute instances use
 
-# Import the v2 tfplan import, but use the alias "tfplan"
-import "tfplan/v2" as tfplan
-
 # Import common-functions/tfplan-functions/tfplan-functions.sentinel
 # with alias "plan"
 import "tfplan-functions" as plan

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-4b/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-4b/setup-sentinel
@@ -5,9 +5,6 @@ set -e
 cat <<-'EOF' > /root/sentinel/restrict-gcp-instance-image-b.sentinel
 # This policy restricts the public images that GCP compute instances use
 
-# Import the v2 tfplan import, but use the alias "tfplan"
-import "tfplan/v2" as tfplan
-
 # Import common-functions/tfplan-functions/tfplan-functions.sentinel
 # with alias "plan"
 import "tfplan-functions" as plan

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-5b/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-5b/setup-sentinel
@@ -10,9 +10,6 @@ cat <<-'EOF' > /root/sentinel/require-modules-from-pmr-b.sentinel
 # root module are in the Private Module Registry (PMR) of a TFC
 # organization.
 
-# Import the v2 tfplan import, but use the alias "tfplan"
-import "tfconfig/v2" as tfconfig
-
 # Import module-functions.sentinel as "modules"
 <import_statement>
 

--- a/instruqt-tracks/sentinel-for-terraform-v3/track.yml
+++ b/instruqt-tracks/sentinel-for-terraform-v3/track.yml
@@ -25,6 +25,7 @@ developers:
 - roger@hashicorp.com
 private: false
 published: true
+show_timer: true
 challenges:
 - slug: exercise-1
   id: jlxuexs2iznt
@@ -92,7 +93,7 @@ challenges:
       You should run the [Sentinel CLI Basics](https://play.instruqt.com/hashicorp/tracks/sentinel-cli-basics) track before starting this track.
   - type: text
     contents: |-
-      We've launched the Sentinel CLI 0.15.2 on a Ubuntu VM running in GCP so that you don't need to download or install it.
+      We've launched the Sentinel CLI 0.15.6 on a Ubuntu VM running in GCP so that you don't need to download or install it.
 
       In this track, you will complete and test policies that have been mostly written for you but have placeholders in angular brackets that you must replace with suitable Sentinel code. When doing this, do not keep the angular brackets, but do keep any quotes that might surround them.
   - type: text
@@ -235,7 +236,7 @@ challenges:
 
     First, in the assignment of the `pgp_key` variable, replace `<expression>` with Sentinel code that will convert `key.change.after.pgp_key` to `null` if it is missing.
 
-    Then replace `<condition_1>` with a condition that tests if the `pgp_key` attribute was missing. This condition should use the `pgp_key` variable.
+    Then replace `<condition_1>` with a condition that tests if the `pgp_key` attribute was missing or null. This condition should use the `pgp_key` variable.
 
     Next, replace `<condition_2>` with a condition that tests if the `pgp_key` variable does **not** start with "keybase:". While there are several ways of doing this, please use the "strings" import which is also used in the "filter_attribute_does_not_have_prefix" function that was used by the "require-access-keys-use-pgp-a.sentinel" policy.
 
@@ -773,4 +774,4 @@ challenges:
     hostname: sentinel
   difficulty: basic
   timelimit: 1800
-checksum: "8308058173547489329"
+checksum: "18241319682764043351"


### PR DESCRIPTION
I removed unneeded imports from policies, namely tfplan/v2 and tfstate/v2, since when using my Sentinel modules like tfplan-functions and tfstate-functions that already reference those imports, the actual policies do not need to import them.

I also updated the Sentinel CLI version from 0.15.2 to 0.15.6.