### PR TITLE
update terraform to 0.13.3 in setup scripts

### DIFF
--- a/docker/workstation/Dockerfile
+++ b/docker/workstation/Dockerfile
@@ -22,7 +22,7 @@ RUN sudo mv /tmp/vim-colors-solarized/colors /root/.vim/colors
 RUN sudo echo -e "let g:solarized_termcolors=256\nset t_Co=256\nsyntax enable\nset background=dark\ncolorscheme solarized" > /tmp/.vimrc
 RUN sudo mv /tmp/.vimrc /root/.vimrc
 RUN wget https://releases.hashicorp.com/terraform/0.12.20/terraform_0.12.20_linux_amd64.zip -O /tmp/terraform.zip
-RUN sudo unzip /tmp/terraform.zip -d /usr/local/bin
+RUN sudo unzip -o /tmp/terraform.zip -d /usr/local/bin
 RUN sudo chmod +x /usr/local/bin/terraform
 ENV VAULT_TOKEN $VAULT_TOKEN
 ENV SHELL=/bin/bash

--- a/instruqt-tracks/terraform-build-aws/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-build-aws/setup-our-environment/setup-workstation
@@ -61,5 +61,11 @@ terraform init
 # Ensure we load /etc/profile.d/instruqt-env.sh
 echo "source /etc/profile.d/instruqt-env.sh" >> /root/.bashrc
 
+# Update Terraform
+echo "Installing Terraform and command line tools."
+wget https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_linux_amd64.zip -O /tmp/terraform.zip
+unzip -o /tmp/terraform.zip -d /usr/local/bin
+chmod +x /usr/local/bin/terraform
+
 # Drop the Terraform extension vsix file into /root
 # wget https://storage.googleapis.com/instruqt-hashicorp-tracks/terraform-shared/mauve.terraform-1.4.0.vsix -O /root/mauve.terraform-1.4.0.vsix

--- a/instruqt-tracks/terraform-build-azure/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-build-azure/setup-our-environment/setup-workstation
@@ -12,6 +12,12 @@ source /root/.bashrc
 # Ensure we load /etc/profile.d/instruqt-env.sh
 echo "source /etc/profile.d/instruqt-env.sh" >> /root/.bashrc
 
+# Update Terraform
+echo "Installing Terraform and command line tools."
+wget https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_linux_amd64.zip -O /tmp/terraform.zip
+unzip -o /tmp/terraform.zip -d /usr/local/bin
+chmod +x /usr/local/bin/terraform
+
 # Import VAULT_TOKEN in case we need to get new creds
 echo "export VAULT_TOKEN=\$(cat /var/vault_token)" >> /root/.bashrc
 

--- a/instruqt-tracks/terraform-build-gcp/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-build-gcp/setup-our-environment/setup-workstation
@@ -8,6 +8,12 @@ sleep 10
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 
+# Update Terraform
+echo "Installing Terraform and command line tools."
+wget https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_linux_amd64.zip -O /tmp/terraform.zip
+unzip -o /tmp/terraform.zip -d /usr/local/bin
+chmod +x /usr/local/bin/terraform
+
 # Clone the hashicat-gcp repo
 git clone https://github.com/hashicorp/hashicat-gcp
 GITDIR="/root/hashicat-gcp"

--- a/instruqt-tracks/terraform-cloud-aws/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/setup-our-environment/setup-workstation
@@ -8,6 +8,12 @@ sleep 10
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 
+# Update Terraform
+echo "Installing Terraform and command line tools."
+wget https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_linux_amd64.zip -O /tmp/terraform.zip
+unzip -o /tmp/terraform.zip -d /usr/local/bin
+chmod +x /usr/local/bin/terraform
+
 # clone the hashicat-aws repo
 git clone https://github.com/hashicorp/hashicat-aws
 GITDIR="/root/hashicat-aws"

--- a/instruqt-tracks/terraform-cloud-azure/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/setup-our-environment/setup-workstation
@@ -8,6 +8,12 @@ sleep 10
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 
+# Update Terraform
+echo "Installing Terraform and command line tools."
+wget https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_linux_amd64.zip -O /tmp/terraform.zip
+unzip -o /tmp/terraform.zip -d /usr/local/bin
+chmod +x /usr/local/bin/terraform
+
 # Generate the Azure creds setup script
 cat <<-EOF > /bin/setup_azure.sh
 #!/bin/bash

--- a/instruqt-tracks/terraform-cloud-bonus-lab/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-bonus-lab/setup-our-environment/setup-workstation
@@ -9,6 +9,12 @@ sleep 10
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 
+# Update Terraform
+echo "Installing Terraform and command line tools."
+wget https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_linux_amd64.zip -O /tmp/terraform.zip
+unzip -o /tmp/terraform.zip -d /usr/local/bin
+chmod +x /usr/local/bin/terraform
+
 # Create code server config directory
 mkdir -p /root/.local/share/code-server/User
 

--- a/instruqt-tracks/terraform-cloud-gcp/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-gcp/setup-our-environment/setup-workstation
@@ -8,6 +8,12 @@ sleep 10
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 
+# Update Terraform
+echo "Installing Terraform and command line tools."
+wget https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_linux_amd64.zip -O /tmp/terraform.zip
+unzip -o /tmp/terraform.zip -d /usr/local/bin
+chmod +x /usr/local/bin/terraform
+
 # clone the hashicat-gcp repo
 git clone https://github.com/hashicorp/hashicat-gcp
 GITDIR="/root/hashicat-gcp"

--- a/instruqt-tracks/terraform-module-lab/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-module-lab/setup-our-environment/setup-workstation
@@ -9,6 +9,12 @@ sleep 10
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 
+# Update Terraform
+echo "Installing Terraform and command line tools."
+wget https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_linux_amd64.zip -O /tmp/terraform.zip
+unzip -o /tmp/terraform.zip -d /usr/local/bin
+chmod +x /usr/local/bin/terraform
+
 # Create code server config directory
 mkdir -p /root/.local/share/code-server/User
 

--- a/instruqt-tracks/terraform-workshop-base/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-workshop-base/setup-our-environment/setup-workstation
@@ -9,6 +9,12 @@ sleep 10
 source /etc/profile.d/instruqt-env.sh
 source /root/.bashrc
 
+# Update Terraform
+echo "Installing Terraform and command line tools."
+wget https://releases.hashicorp.com/terraform/0.13.3/terraform_0.13.3_linux_amd64.zip -O /tmp/terraform.zip
+unzip -o /tmp/terraform.zip -d /usr/local/bin
+chmod +x /usr/local/bin/terraform
+
 # Create code server config directory
 mkdir -p /root/.local/share/code-server/User
 


### PR DESCRIPTION
Overriding image of the terraform-workstation-prod image in the setup scripts of the tracks since I have permission to do that and don't have permission to update the hc-fto/terraform-workstation repo. This will make updating version of Terraform easier by the Terraform SMEs in the future easier too.