### PR TITLE
remove some confusing TFC external tabs

### DIFF
--- a/instruqt-tracks/terraform-cloud-aws/track.yml
+++ b/instruqt-tracks/terraform-cloud-aws/track.yml
@@ -120,9 +120,6 @@ challenges:
   - type: text
     contents: Terraform Cloud remote state storage is free for all users.
   tabs:
-  - title: Terraform Cloud
-    type: external
-    url: https://app.terraform.io
   - title: Shell
     type: terminal
     hostname: workstation
@@ -203,9 +200,6 @@ challenges:
   - title: Shell
     type: terminal
     hostname: workstation
-  - title: Terraform Cloud
-    type: external
-    url: https://app.terraform.io
   difficulty: basic
   timelimit: 1800
 - slug: quiz-1

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -120,9 +120,9 @@ challenges:
   - type: text
     contents: Terraform Cloud remote state storage is free for all users.
   tabs:
-  - title: Terraform Cloud
-    type: external
-    url: https://app.terraform.io
+  - title: Shell
+    type: terminal
+    hostname: workstation
   difficulty: basic
   timelimit: 1800
 - slug: oh-no-an-outage
@@ -208,9 +208,6 @@ challenges:
   - title: Shell
     type: terminal
     hostname: workstation
-  - title: Terraform Cloud
-    type: external
-    url: https://app.terraform.io
   difficulty: basic
   timelimit: 1800
 - slug: quiz-1

--- a/instruqt-tracks/terraform-cloud-gcp/track.yml
+++ b/instruqt-tracks/terraform-cloud-gcp/track.yml
@@ -120,9 +120,6 @@ challenges:
   - type: text
     contents: Terraform Cloud remote state storage is free for all users.
   tabs:
-  - title: Terraform Cloud
-    type: external
-    url: https://app.terraform.io
   - title: Shell
     type: terminal
     hostname: workstation
@@ -203,9 +200,6 @@ challenges:
   - title: Shell
     type: terminal
     hostname: workstation
-  - title: Terraform Cloud
-    type: external
-    url: https://app.terraform.io
   difficulty: basic
   timelimit: 1800
 - slug: quiz-1


### PR DESCRIPTION
remove first 2 TFC external tabs that are confusing because the assignments do not refer to them and there are links in the assignments that can be used to link to TFC UI