### PR TITLE
clarify addition of tag, shorten GCP track title

### DIFF
--- a/instruqt-tracks/terraform-build-aws/track.yml
+++ b/instruqt-tracks/terraform-build-aws/track.yml
@@ -637,7 +637,7 @@ challenges:
 
     Add a tag to your VPC resource in the **main.tf** file. The name of the tag should be `environment` and the value should be `Production`. (The tag is case-sensitive. Make sure you use a capital P.)
 
-    Hint: Read the examples carefully! Unlike the other resource arguments you've seen, the value of the `tags` argument must be a **map** (a `{key = "value"}` data structure). For more about Terraform's data types, [see the Terraform language documentation](https://www.terraform.io/docs/configuration/expressions.html#types-and-values).
+    Hint: Read the examples carefully! Unlike the other resource arguments you've seen, the value of the `tags` argument must be a **map** (a `{key = "value"}` data structure). Additionally, you must use `=` after `tags` and after `environment`. For more about Terraform's data types, see the [Terraform language documentation](https://www.terraform.io/docs/configuration/expressions.html#types-and-values).
 
     Re-run `terraform apply`.
 

--- a/instruqt-tracks/terraform-build-azure/track.yml
+++ b/instruqt-tracks/terraform-build-azure/track.yml
@@ -644,9 +644,9 @@ challenges:
 
     [Azure Terraform Docs - Click Here](https://www.terraform.io/docs/providers/azurerm/r/resource_group.html)
 
-    Add a tag to your resource group in the **main.tf** file.
+    Add a tag to your resource group in the **main.tf** file using the `tags` argument of the `azurerm_resource_group` resource.
 
-    The name of the tag should be `environment` and the value should be `Production`. The tag is case-sensitive. Make sure you use a capital P.
+    The name of the tag should be `environment` and the value should be `Production`. The tag is case-sensitive. Make sure you use a capital P. You'll need to use `=` after `tags` and after `environment`.
 
     Re-run `terraform apply`.
 

--- a/instruqt-tracks/terraform-build-gcp/track.yml
+++ b/instruqt-tracks/terraform-build-gcp/track.yml
@@ -1,7 +1,7 @@
 slug: terraform-build-gcp
 id: wykyne6vqrul
 type: track
-title: Intro to Terraform on Google Cloud Platform
+title: Intro to Terraform on Google
 teaser: |
   Provision the HashiCat application on GCP using Terraform.
 description: |-


### PR DESCRIPTION
clarify adding of tag to resources in AWS and Azure build workshops.
Shorten title of GCP build track