### PR TITLE
add policy names at top

### DIFF
--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-1/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-1/setup-sentinel
@@ -1499,6 +1499,7 @@ EOF
 
 # restrict-vault-auth-methods
 cat <<-'EOF' > /root/sentinel/restrict-vault-auth-methods.sentinel
+# restrict-vault-auth-methods.sentinel
 # This policy restricts which Vault auth methods can be created
 
 # Import common-functions/tfplan-functions/tfplan-functions.sentinel

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-2a/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-2a/setup-sentinel
@@ -3,6 +3,7 @@
 set -e
 
 cat <<-'EOF' > /root/sentinel/require-access-keys-use-pgp-a.sentinel
+# require-access-keys-use-pgp-a.sentinel
 # This policy requires AWS IAM access keys to use PGP keys
 
 # Import common-functions/tfplan-functions/tfplan-functions.sentinel

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-2b/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-2b/setup-sentinel
@@ -3,6 +3,7 @@
 set -e
 
 cat <<-'EOF' > /root/sentinel/require-access-keys-use-pgp-b.sentinel
+# require-access-keys-use-pgp-b.sentinel
 # This policy requires AWS IAM access keys to use PGP keys
 
 # Import common-functions/tfplan-functions/tfplan-functions.sentinel

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-3a/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-3a/setup-sentinel
@@ -3,6 +3,7 @@
 set -e
 
 cat <<-'EOF' > /root/sentinel/restrict-acm-certificate-domains-a.sentinel
+# restrict-acm-certificate-domains-a.sentinel
 # This policy uses the tfstate import to restrict ACM certificates
 # to have domains that are sub-domains of hashidemos.io
 

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-3b/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-3b/setup-sentinel
@@ -3,6 +3,7 @@
 set -e
 
 cat <<-'EOF' > /root/sentinel/restrict-acm-certificate-domains-b.sentinel
+# restrict-acm-certificate-domains-b.sentinel
 # This policy uses the tfstate import to restrict ACM certificates
 # to have domains that are sub-domains of hashidemos.io
 

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-4a/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-4a/setup-sentinel
@@ -3,6 +3,7 @@
 set -e
 
 cat <<-'EOF' > /root/sentinel/restrict-gcp-instance-image-a.sentinel
+# restrict-gcp-instance-image-a.sentinel
 # This policy restricts the public images that GCP compute instances use
 
 # Import common-functions/tfplan-functions/tfplan-functions.sentinel

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-4b/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-4b/setup-sentinel
@@ -3,6 +3,7 @@
 set -e
 
 cat <<-'EOF' > /root/sentinel/restrict-gcp-instance-image-b.sentinel
+# restrict-gcp-instance-image-b.sentinel
 # This policy restricts the public images that GCP compute instances use
 
 # Import common-functions/tfplan-functions/tfplan-functions.sentinel

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-5a/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-5a/setup-sentinel
@@ -3,6 +3,7 @@
 set -e
 
 cat <<-'EOF' > /root/sentinel/require-modules-from-pmr-a.sentinel
+# require-modules-from-pmr-a.sentinel
 # This policy validates that all modules loaded directly by the
 # root module are in the Private Module Registry (PMR) of a TFC
 # organization.

--- a/instruqt-tracks/sentinel-for-terraform-v3/exercise-5b/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/exercise-5b/setup-sentinel
@@ -6,6 +6,7 @@ set -e
 mkdir -p /root/sentinel/common-functions/module-functions
 
 cat <<-'EOF' > /root/sentinel/require-modules-from-pmr-b.sentinel
+# require-modules-from-pmr-b.sentinel
 # This policy validates that all modules loaded directly by the
 # root module are in the Private Module Registry (PMR) of a TFC
 # organization.

--- a/instruqt-tracks/sentinel-for-terraform-v3/extra-credit/setup-sentinel
+++ b/instruqt-tracks/sentinel-for-terraform-v3/extra-credit/setup-sentinel
@@ -3,6 +3,7 @@
 set -e
 
 cat <<-'EOF' > /root/sentinel/prevent-auto-apply-in-production.sentinel
+# prevent-auto-apply-in-production.sentinel
 # This policy uses the Sentinel tfrun import to prevent the use of auto-apply
 # in workspaces with names matching "^prod-(.*)" or "(.*)-prod$"
 

--- a/instruqt-tracks/sentinel-for-terraform-v3/track.yml
+++ b/instruqt-tracks/sentinel-for-terraform-v3/track.yml
@@ -120,7 +120,7 @@ challenges:
 
       If you look at the links for various Vault auth methods under the second of these links, you'll see that the `vault auth enable` command always specifies the auth method type with a single lower-case string identical to or similar to the full name of the auth method. These strings are also what the Terraform Vault Provider uses when creating Vault auth methods.
   tabs:
-  - title: Policies
+  - title: Sentinel Policies
     type: code
     hostname: sentinel
     path: /root/sentinel/
@@ -511,7 +511,7 @@ challenges:
 
     Accordingly, please open the "restrict-gcp-instance-image-b.sentinel" policy and observe that it also has several placeholders in angular brackets that need to be replaced.
 
-    First, replace `<expression_1>` in the line that assigns a value to the `boot_disk` variable with an expression that gives the data of the `boot_disk` block of the "google_compute_instance" resource. For a hint about the structure of your replacement, see line 19 of the "require-access-keys-use-pgp-b.sentinel" policy on the "Policies" tab, but don't bother adding `else null` to your expression.
+    First, replace `<expression_1>` in the line that assigns a value to the `boot_disk` variable with an expression that gives the data of the `boot_disk` block of the "google_compute_instance" resource. For a hint about the structure of your replacement, see line 18 of the "require-access-keys-use-pgp-b.sentinel" policy on the "Policies" tab, but don't bother adding `else null` to your expression.
 
     We use the `types` import to check if `<expression_2>` is a list since we will try to access elements of it in the `else` statement and would get an error if it is not a list (which would be the case if it were missing or `null`). We did not need to check the type of the `boot_disk` block because it is a required block of the resource and therefore cannot be missing.
 
@@ -774,4 +774,4 @@ challenges:
     hostname: sentinel
   difficulty: basic
   timelimit: 1800
-checksum: "18241319682764043351"
+checksum: "12770385458511956458"


### PR DESCRIPTION
Adding names of Sentinel policies at top to make it easier to distinguish between versions a and b for exercises 2-5