### PR TITLE
use bigger circleci container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ jobs:
   instruqt-test-oss-azure:
     docker:
       - image: ubuntu:latest
+    resource_class: large
     steps:
       - checkout
       - run:


### PR DESCRIPTION
for the instruqt-test-oss-azure job, set resource_class to large to see if that fixes problem with that test.