### PR TITLE
remove bash_history checks, inject env vars to code-server

### DIFF
--- a/instruqt-tracks/terraform-intro-aws/aws-credentials/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/aws-credentials/check-workstation
@@ -7,6 +7,6 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q "echo \$AWS_SECRET_ACCESS_KEY" /root/.bash_history || fail-message "You haven't checked your credentials yet."
+# grep -q "echo \$AWS_SECRET_ACCESS_KEY" /root/.bash_history || fail-message "You haven't checked your credentials yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/hello-terraform/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/hello-terraform/check-workstation
@@ -7,8 +7,8 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q "terraform version" /root/.bash_history || fail-message "You haven't run terraform version yet."
+# grep -q "terraform version" /root/.bash_history || fail-message "You haven't run terraform version yet."
 
-grep -q "terraform help" /root/.bash_history || fail-message "You haven't run terraform help yet."
+# grep -q "terraform help" /root/.bash_history || fail-message "You haven't run terraform help yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-intro-aws/setup-our-environment/setup-workstation
@@ -34,6 +34,10 @@ ExecStart=/usr/bin/code-server --host 0.0.0.0 --port 8443 --cert --auth none /ro
 WantedBy=multi-user.target
 EOF
 
+# Add AWS keys to systemd environment
+systemctl import-environment AWS_ACCESS_KEY_ID
+systemctl import-environment AWS_SECRET_ACCESS_KEY
+
 # Start VSC
 systemctl enable code-server
 systemctl start code-server

--- a/instruqt-tracks/terraform-intro-aws/terraform-plan/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/terraform-plan/check-workstation
@@ -7,6 +7,6 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q "terraform plan" /root/.bash_history || fail-message "You haven't run terraform plan yet."
+# grep -q "terraform plan" /root/.bash_history || fail-message "You haven't run terraform plan yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/tf-plan-again/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/tf-plan-again/check-workstation
@@ -7,6 +7,6 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q "terraform plan" /root/.bash_history || fail-message "You have not re-run terraform plan yet."
+# grep -q "terraform plan" /root/.bash_history || fail-message "You have not re-run terraform plan yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/tf-plan-again/setup-workstation
+++ b/instruqt-tracks/terraform-intro-aws/tf-plan-again/setup-workstation
@@ -4,7 +4,7 @@ set -e
 
 set-workdir /root/hashicat-aws
 
-rm /root/.bash_history
-touch /root/.bash_history
+# rm /root/.bash_history
+# touch /root/.bash_history
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/track.yml
+++ b/instruqt-tracks/terraform-intro-aws/track.yml
@@ -329,7 +329,9 @@ challenges:
 
     When you run this command Terraform will prompt you to enter the `prefix` variable.
 
-    Enter a short string of lower-case letters and/or numbers. You can use your own name here if you wish. The prefix will become part of the name for our VPC, subnet, EC2 instance and other resources.
+    Enter a short string of lower-case letters and/or numbers. We recommend that you use your first and last name.
+
+    The prefix will become part of the name for our VPC, subnet, EC2 instance and other resources.
   notes:
   - type: text
     contents: |-
@@ -1129,4 +1131,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1000
-checksum: "2665246642536675128"
+checksum: "11066000112727208385"

--- a/instruqt-tracks/terraform-intro-azure/azure-credentials/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/azure-credentials/check-workstation
@@ -7,6 +7,6 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q "env | grep ARM_CLIENT" /root/.bash_history || fail-message "You haven't checked your Azure credentials yet."
+# grep -q "env | grep ARM_CLIENT" /root/.bash_history || fail-message "You haven't checked your Azure credentials yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/hello-terraform/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/hello-terraform/check-workstation
@@ -7,8 +7,8 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q "terraform version" /root/.bash_history || fail-message "You haven't run terraform version yet."
+# grep -q "terraform version" /root/.bash_history || fail-message "You haven't run terraform version yet."
 
-grep -q "terraform help" /root/.bash_history || fail-message "You haven't run terraform help yet."
+# grep -q "terraform help" /root/.bash_history || fail-message "You haven't run terraform help yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-intro-azure/setup-our-environment/setup-workstation
@@ -15,7 +15,7 @@ set-workdir /root/hashicat-azure
 cd ${GITDIR}
 cp ${GITDIR}/exercises/main.tf.start ${GITDIR}/main.tf
 cp ${GITDIR}/exercises/outputs.tf.start ${GITDIR}/outputs.tf
-echo -e "\nlocation = \"centralus\"" >> ${GITDIR}/terraform.tfvars
+mv ${GITDIR}/terraform.tfvars.example ${GITDIR}/terraform.tfvars
 
 # Start up Visual Studio Code server
 # Create VSC startup script
@@ -35,6 +35,12 @@ ExecStart=/usr/bin/code-server --host 0.0.0.0 --port 8443 --cert --auth none /ro
 [Install]
 WantedBy=multi-user.target
 EOF
+
+# Add Azure creds to systemd environment
+systemctl import-environment ARM_SUBSCRIPTION_ID
+systemctl import-environment ARM_TENANT_ID
+systemctl import-environment ARM_CLIENT_ID
+systemctl import-environment ARM_CLIENT_SECRET
 
 # Start VSC
 systemctl enable code-server

--- a/instruqt-tracks/terraform-intro-azure/terraform-plan/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/terraform-plan/check-workstation
@@ -7,6 +7,6 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q "terraform plan" /root/.bash_history || fail-message "You haven't run terraform plan yet."
+# grep -q "terraform plan" /root/.bash_history || fail-message "You haven't run terraform plan yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/tf-plan-again/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/tf-plan-again/check-workstation
@@ -7,6 +7,6 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q "terraform plan" /root/.bash_history || fail-message "You have not re-run terraform plan yet."
+# grep -q "terraform plan" /root/.bash_history || fail-message "You have not re-run terraform plan yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/tf-plan-again/setup-workstation
+++ b/instruqt-tracks/terraform-intro-azure/tf-plan-again/setup-workstation
@@ -4,7 +4,7 @@ set -e
 
 set-workdir /root/hashicat-azure
 
-rm /root/.bash_history
-touch /root/.bash_history
+# rm /root/.bash_history
+# touch /root/.bash_history
 
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/track.yml
+++ b/instruqt-tracks/terraform-intro-azure/track.yml
@@ -327,7 +327,7 @@ challenges:
     ```
     When you run this command Terraform will prompt you to enter the `prefix` variable.
 
-    Enter a short string of lower-case letters and/or numbers. You can use your own name here if you wish.
+    Enter a short string of lower-case letters and/or numbers. We recommend that you use your first and last name.
 
     **Keep your prefix string all lower case, and between 5-12 characters long. Do not use an underscore in your prefix.**
 
@@ -1124,4 +1124,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1067
-checksum: "16304104145570246559"
+checksum: "12723157040512874749"

--- a/instruqt-tracks/terraform-intro-gcp/gcp-credentials/check-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/gcp-credentials/check-workstation
@@ -7,6 +7,6 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q "echo \$GOOGLE_CREDENTIALS" /root/.bash_history || fail-message "You haven't checked your credentials yet."
+# grep -q "echo \$GOOGLE_CREDENTIALS" /root/.bash_history || fail-message "You haven't checked your credentials yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-gcp/hello-terraform/check-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/hello-terraform/check-workstation
@@ -7,8 +7,8 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q "terraform version" /root/.bash_history || fail-message "You haven't run terraform version yet."
+# grep -q "terraform version" /root/.bash_history || fail-message "You haven't run terraform version yet."
 
-grep -q "terraform help" /root/.bash_history || fail-message "You haven't run terraform help yet."
+# grep -q "terraform help" /root/.bash_history || fail-message "You haven't run terraform help yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-gcp/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/setup-our-environment/setup-workstation
@@ -15,6 +15,12 @@ cp ${GITDIR}/exercises/main.tf.start ${GITDIR}/main.tf
 cp ${GITDIR}/exercises/outputs.tf.start ${GITDIR}/outputs.tf
 mv ${GITDIR}/terraform.tfvars.example ${GITDIR}/terraform.tfvars
 
+# Store our project ID as a Terraform env var
+export TF_VAR_project=$INSTRUQT_GCP_PROJECT_GCP_PROJECT_PROJECT_ID
+grep $INSTRUQT_GCP_PROJECT_GCP_PROJECT_PROJECT_ID /root/.bashrc || echo "export TF_VAR_project=\"$INSTRUQT_GCP_PROJECT_GCP_PROJECT_PROJECT_ID\"" >> /root/.bashrc
+export GOOGLE_CREDENTIALS=$(echo $INSTRUQT_GCP_PROJECT_GCP_PROJECT_SERVICE_ACCOUNT_KEY | base64 -d | jq 'tostring')
+echo "export GOOGLE_CREDENTIALS=$GOOGLE_CREDENTIALS" >> /root/.bashrc
+
 # Start up Visual Studio Code server
 # Create VSC startup script
 cat <<-EOF > /etc/systemd/system/code-server.service
@@ -34,12 +40,13 @@ ExecStart=/usr/bin/code-server --host 0.0.0.0 --port 8443 --cert --auth none /ro
 WantedBy=multi-user.target
 EOF
 
+# Add GCP creds to systemd environment
+systemctl import-environment INSTRUQT_GCP_PROJECT_GCP_PROJECT_PROJECT_ID
+systemctl import-environment TF_VAR_project
+systemctl import-environment GOOGLE_CREDENTIALS
+
 # Start VSC
 systemctl enable code-server
 systemctl start code-server
-
-# Store our project ID as a Terraform env var
-grep $INSTRUQT_GCP_PROJECT_GCP_PROJECT_PROJECT_ID /root/.bashrc || echo "export TF_VAR_project=\"$INSTRUQT_GCP_PROJECT_GCP_PROJECT_PROJECT_ID\"" >> /root/.bashrc
-echo 'export GOOGLE_CREDENTIALS=$(echo $INSTRUQT_GCP_PROJECT_GCP_PROJECT_SERVICE_ACCOUNT_KEY | base64 -d)' >> /root/.bashrc
 
 exit 0

--- a/instruqt-tracks/terraform-intro-gcp/terraform-plan/check-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/terraform-plan/check-workstation
@@ -7,6 +7,6 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q "terraform plan" /root/.bash_history || fail-message "You haven't run terraform plan yet."
+# grep -q "terraform plan" /root/.bash_history || fail-message "You haven't run terraform plan yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-gcp/tf-plan-again/check-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/tf-plan-again/check-workstation
@@ -7,6 +7,6 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-grep -q "terraform plan" /root/.bash_history || fail-message "You have not re-run terraform plan yet."
+# grep -q "terraform plan" /root/.bash_history || fail-message "You have not re-run terraform plan yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-gcp/tf-plan-again/setup-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/tf-plan-again/setup-workstation
@@ -4,7 +4,7 @@ set -e
 
 set-workdir /root/hashicat-gcp
 
-rm /root/.bash_history
-touch /root/.bash_history
+# rm /root/.bash_history
+# touch /root/.bash_history
 
 exit 0

--- a/instruqt-tracks/terraform-intro-gcp/track.yml
+++ b/instruqt-tracks/terraform-intro-gcp/track.yml
@@ -323,7 +323,9 @@ challenges:
 
     When you run this command Terraform will prompt you to enter the `prefix` variable.
 
-    Enter a short string of lower-case letters and/or numbers. You can use your own name here if you wish. The prefix will become part of the name for our VPC network, subnet, and compute instance, as well as appear in the HashiCat application.
+    Enter a short string of lower-case letters and/or numbers. We recommend that you use your first and last name.
+
+    The prefix will become part of the name for our VPC network, subnet, and compute instance, as well as appear in the HashiCat application.
   notes:
   - type: text
     contents: |-
@@ -357,7 +359,7 @@ challenges:
 
     In Terraform all variables must be declared (with or without an optional default value) before you can use them.
 
-    Open the `terraform.tfvars` file and set your prefix variable there.
+    Open the **terraform.tfvars** file and set your prefix variable by deleting the `#` at the beginning of the line and replacing "yourname" with your own name. The file will auto-save.
 
     Now run `terraform plan` again. This time you won't have to enter your prefix manually.
   notes:
@@ -1086,4 +1088,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1000
-checksum: "10036889096121338848"
+checksum: "16874763366103748551"


### PR DESCRIPTION
This removes checks against /root/.bash_history so that commands can be done in the VS Code Editor terminal.  Commands done there were not showing up in .bash_history until the next challenge which was too late.

I also injected the cloud credentials environment variables into the systemctl environment for the 3 Intro to Terraform tracks so that terraform commands can be run in the terminal. 