### PR TITLE
tell user to set terraform version

### DIFF
--- a/instruqt-tracks/terraform-cloud-aws/track.yml
+++ b/instruqt-tracks/terraform-cloud-aws/track.yml
@@ -111,7 +111,9 @@ challenges:
 
     DO NOT SKIP THIS NEXT STEP:
 
-    Go into the workspace's **Settings >> General** settings page and change the **Execution Mode** to local.
+    Go into the workspace's **Settings >> General** settings page and change the **Execution Mode** to **Local**.
+
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match. This will avoid possible errors later in this track.
 
     Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables.
 

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -111,7 +111,9 @@ challenges:
 
     DO NOT SKIP THIS NEXT STEP:
 
-    Go into the workspace's **Settings >> General** settings page and change the **Execution Mode** to local.
+    Go into the workspace's **Settings >> General** settings page and change the **Execution Mode** to **Local**.
+
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match. This will avoid possible errors later in this track.
 
     Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables.
 

--- a/instruqt-tracks/terraform-cloud-gcp/track.yml
+++ b/instruqt-tracks/terraform-cloud-gcp/track.yml
@@ -115,6 +115,8 @@ challenges:
 
     Go into the workspace's **Settings >> General** settings page and change the **Execution Mode** to **Local**.
 
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match. This will avoid possible errors later in this track.
+
     Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables.
 
     Enable a free trial of Terraform Cloud paid features by navigating to the top menu bar's **Settings** > **Plan & Billing**, select **Trial Plan**, and click the button for **Start your free trial**.

--- a/instruqt-tracks/terraform-intro-aws/track.yml
+++ b/instruqt-tracks/terraform-intro-aws/track.yml
@@ -1014,7 +1014,11 @@ challenges:
 
     Next you'll be prompted to create a workspace. You can skip the VCS integration step by clicking the "CLI-driven workflow" panel. Name your workspace **hashicat-aws**.
 
-    Now go into the workspace's **Settings >> General** settings page and change the Execution Mode to local. Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
+    Now go into the workspace's **Settings >> General** settings page and change the Execution Mode to **Local**.
+
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match. This will avoid possible errors later in this track.
+
+    Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
   notes:
   - type: text
     contents: Terraform Cloud remote state storage is free for all users.

--- a/instruqt-tracks/terraform-intro-azure/track.yml
+++ b/instruqt-tracks/terraform-intro-azure/track.yml
@@ -1011,7 +1011,11 @@ challenges:
 
     Next you'll be prompted to create a workspace. You can skip the VCS integration step by clicking the "CLI-driven workflow" panel. Name your workspace **hashicat-azure**.
 
-    Now go into the workspace's **Settings >> General** settings page and change the Execution Mode to local. **Be sure to save your settings!** This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
+    Now go into the workspace's **Settings >> General** settings page and change the Execution Mode to **Local**.
+
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match. This will avoid possible errors later in this track.
+
+    Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
   notes:
   - type: text
     contents: Terraform Cloud remote state storage is free for all users.

--- a/instruqt-tracks/terraform-intro-gcp/track.yml
+++ b/instruqt-tracks/terraform-intro-gcp/track.yml
@@ -971,7 +971,11 @@ challenges:
 
     Next you'll be prompted to create a workspace. You can skip the VCS integration step by clicking the "CLI-driven workflow" panel. Name your workspace **hashicat-gcp**.
 
-    Now go into the workspace's **Settings >> General** settings page and change the Execution Mode to local. Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
+    Now go into the workspace's **Settings >> General** settings page and change the Execution Mode to **Local**.
+
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match. This will avoid possible errors later in this track.
+
+    Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
   notes:
   - type: text
     contents: Terraform Cloud remote state storage is free for all users.


### PR DESCRIPTION
Tell user to set Terraform version in General settings of their TFC workspace to avoid possible state version mismatches.
We say to check version on workstation VM with `terraform version` and then pick matching version.