### PR TITLE
instruct user to refork existing repos and recreate workspaces

### DIFF
--- a/instruqt-tracks/terraform-cloud-aws/track.yml
+++ b/instruqt-tracks/terraform-cloud-aws/track.yml
@@ -109,13 +109,15 @@ challenges:
 
     No really...you *must* name your workspace **hashicat-aws**. If you don't the exercises will break. Do not attempt to name it something else.
 
+    **Note:** If you already have a **hashicat-aws** workspace, please delete the workspace by selecting the **Settings >> Destruction and Deletion** menu, clicking the "Delete from Terraform Cloud" button, typing "hashicat-aws" to confirm, and then clicking the "Delete workspace" button. Then re-create it as above. Doing this avoids possible problems with mis-matched state versions when executing local runs after having executed remote runs. This could happen if you already played this track in the past.
+
     DO NOT SKIP THIS NEXT STEP:
 
     Go into the workspace's **Settings >> General** settings page and change the **Execution Mode** to **Local**.
 
-    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match. This will avoid possible errors later in this track.
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match.
 
-    Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables.
+    Be sure to save your settings by clicking the "Save settings" button at the bottom of the page! This will allow us to run Terraform commands from our workstation with local variables.
 
     Enable a free trial of Terraform Cloud paid features by navigating to: **Settings** > **Plan & Billing**, select **Trial Plan**, and click the button for **Start your free trial**.
 
@@ -430,6 +432,8 @@ challenges:
 
     https://github.com/hashicorp/hashicat-aws
 
+    **Note:** If you ran this track in the past and already forked the repository, please delete your fork and re-fork it to make sure you are using the latest version and that it does not have changes which you will push to it later in this track. You can delete a repository by clicking on the "Settings" menu of it, scrolling all the way to the bottom of the page, clicking the "Delete this repository" button in the "Danger Zone" section, typing the full repository name, and then clicking the "I understand the consequences, delete this repository" button. Then re-fork the repository as above.
+
     Run the following commands to update your git configuration for your own repository. Don't forget to replace YOURGITUSER with your own git username in the second command.
 
     ```
@@ -524,7 +528,7 @@ challenges:
   assignment: |-
     In this challenge you'll make a small change to the code that deploys the hashicat-aws application, and then create a "Pull Request", which is simply a way of proposing a change and optionally allowing others to review your changes.
 
-    Find a partner, or if you're alone you can do this exercise solo. Exchange github usernames and browse to the other person's **fork** of the hashicat-aws repository. For example:
+    Find a partner, or if you're alone you can do this exercise solo. Exchange github usernames and browse to the other person's fork of the hashicat-aws repository. For example:
 
     https://github.com/YOURNAME/hashicat-aws
 
@@ -589,6 +593,8 @@ challenges:
     1. Create a fork of the following GitHub repo, which contains several Sentinel Policy Sets that you can use in your own organization. As you did with the hashicat-aws repo, use the **Fork** button in the upper right corner of the screen to create your own copy.
 
     https://github.com/hashicorp/tfc-workshops-sentinel
+
+    **Note:**: If you previously forked this repository before 9/20/2020, please delete your fork and re-fork it to ensure that you are using newer versions of the policies that use the Sentinel v2 imports.
 
     Before moving on, please look at the [enforce-mandatory-tags](https://github.com/hashicorp/tfc-workshops-sentinel/blob/master/aws/enforce-mandatory-tags.sentinel) policy. This policy requires all EC2 instances to have `Department` and `Billable` tags. It uses some functions from a Sentinel module in a different repository called [terraform-guides](https://github.com/hashicorp/terraform-guides). You'll find many useful Sentinel policies and functions in its [governance/third-generation](https://github.com/hashicorp/terraform-guides/tree/master/governance/third-generation) directory.
 

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -107,15 +107,17 @@ challenges:
 
     Next you'll be prompted to create a workspace. Select the "CLI-driven workflow" panel, type **hashicat-azure**, and click the "Create workspace" button.
 
-    No really...you *must* name your workspace **hashicat-azure**. If you don't the exercises will break. Do not attempt to name it something else.
+    No really...you *must* name your workspace **hashicat-azure**. If you don't, the exercises will break. Do not attempt to name it something else.
+
+    **Note:** If you already have a **hashicat-azure** workspace, please delete the workspace by selecting the **Settings >> Destruction and Deletion** menu, clicking the "Delete from Terraform Cloud" button, typing "hashicat-azure" to confirm, and then clicking the "Delete workspace" button. Then re-create it as above. Doing this avoids possible problems with mis-matched state versions when executing local runs after having executed remote runs. This could happen if you already played this track in the past.
 
     DO NOT SKIP THIS NEXT STEP:
 
     Go into the workspace's **Settings >> General** settings page and change the **Execution Mode** to **Local**.
 
-    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match. This will avoid possible errors later in this track.
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match.
 
-    Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables.
+    Be sure to save your settings by clicking the "Save settings" button at the bottom of the page! This will allow us to run Terraform commands from our workstation with local variables.
 
     Enable a free trial of Terraform Cloud paid features by navigating to: **Settings** > **Plan & Billing**, select **Trial Plan**, and click the button for **Start your free trial**.
 
@@ -436,6 +438,8 @@ challenges:
 
     https://github.com/hashicorp/hashicat-azure
 
+    **Note:** If you ran this track in the past and already forked the repository, please delete your fork and re-fork it to make sure you are using the latest version and that it does not have changes which you will push to it later in this track. You can delete a repository by clicking on the "Settings" menu of it, scrolling all the way to the bottom of the page, clicking the "Delete this repository" button in the "Danger Zone" section, typing the full repository name, and then clicking the "I understand the consequences, delete this repository" button. Then re-fork the repository as above.
+
     Run the following commands to update your git configuration for your own repository. Don't forget to replace YOURGITUSER with your own git username in the second command.
 
     ```
@@ -530,7 +534,7 @@ challenges:
   assignment: |-
     In this challenge you'll make a small change to the code that deploys the hashicat-azure application, and then create a "Pull Request", which is simply a way of proposing a change and optionally allowing others to review your changes.
 
-    Find a partner, or if you're alone you can do this exercise solo. Exchange github usernames and browse to the other person's **fork** of the hashicat-azure repository. For example:
+    Find a partner, or if you're alone you can do this exercise solo. Exchange github usernames and browse to the other person's fork of the hashicat-azure repository. For example:
 
     https://github.com/YOURNAME/hashicat-azure
 
@@ -595,6 +599,8 @@ challenges:
     1. Create a fork of the following GitHub repo, which contains a Sentinel Policy Set that you can use in your own organization. As you did with the hashicat-azure repo, use the **Fork** button in the upper right corner of the screen to create your own copy.
 
     https://github.com/hashicorp/tfc-workshops-sentinel
+
+    **Note:**: If you previously forked this repository before 9/20/2020, please delete your fork and re-fork it to ensure that you are using newer versions of the policies that use the Sentinel v2 imports.
 
     Before moving on, please look at the [enforce-mandatory-tags](https://github.com/hashicorp/tfc-workshops-sentinel/blob/master/azure/enforce-mandatory-tags.sentinel) policy. This policy requires all Azure VMs to have `Department` and `Billable` tags. It uses some functions from a Sentinel module in a different repository called [terraform-guides](https://github.com/hashicorp/terraform-guides). You'll find many useful Sentinel policies and functions in its [governance/third-generation](https://github.com/hashicorp/terraform-guides/tree/master/governance/third-generation) directory.
 

--- a/instruqt-tracks/terraform-cloud-gcp/track.yml
+++ b/instruqt-tracks/terraform-cloud-gcp/track.yml
@@ -109,15 +109,17 @@ challenges:
 
     Next you'll be prompted to create a workspace. Select the "CLI-driven workflow" panel, type **hashicat-gcp**, and click the "Create workspace" button.
 
-    No really...you *must* name your workspace **hashicat-gcp**. If you don't the exercises will break. Do not attempt to name it something else.
+    No really...you *must* name your workspace **hashicat-gcp**. If you don't, the exercises will break. Do not attempt to name it something else.
+
+    **Note:** If you already have a **hashicat-gcp** workspace, please delete the workspace by selecting the **Settings >> Destruction and Deletion** menu, clicking the "Delete from Terraform Cloud" button, typing "hashicat-gcp" to confirm, and then clicking the "Delete workspace" button. Then re-create it as above. Doing this avoids possible problems with mis-matched state versions when executing local runs after having executed remote runs. This could happen if you already played this track in the past.
 
     DO NOT SKIP THIS NEXT STEP:
 
     Go into the workspace's **Settings >> General** settings page and change the **Execution Mode** to **Local**.
 
-    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match. This will avoid possible errors later in this track.
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match.
 
-    Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables.
+    Be sure to save your settings by clicking the "Save settings" button at the bottom of the page! This will allow us to run Terraform commands from our workstation with local variables.
 
     Enable a free trial of Terraform Cloud paid features by navigating to the top menu bar's **Settings** > **Plan & Billing**, select **Trial Plan**, and click the button for **Start your free trial**.
 
@@ -436,6 +438,8 @@ challenges:
 
     https://github.com/hashicorp/hashicat-gcp
 
+    **Note:** If you ran this track in the past and already forked the repository, please delete your fork and re-fork it to make sure you are using the latest version and that it does not have changes which you will push to it later in this track. You can delete a repository by clicking on the "Settings" menu of it, scrolling all the way to the bottom of the page, clicking the "Delete this repository" button in the "Danger Zone" section, typing the full repository name, and then clicking the "I understand the consequences, delete this repository" button. Then re-fork the repository as above.
+
     Run the following commands to update your git configuration for your own repository. Don't forget to replace YOURGITUSER with your own git username in the second command.
 
     ```
@@ -530,7 +534,7 @@ challenges:
   assignment: |-
     In this challenge you'll make a small change to the code that deploys the hashicat-gcp application, and then create a "Pull Request", which is simply a way of proposing a change and optionally allowing others to review your changes.
 
-    Find a partner, or if you're alone you can do this exercise solo. Exchange github usernames and browse to the other person's **fork** of the hashicat-gcp repository. For example:
+    Find a partner, or if you're alone you can do this exercise solo. Exchange github usernames and browse to the other person's fork of the hashicat-gcp repository. For example:
 
     https://github.com/YOURNAME/hashicat-gcp
 
@@ -595,6 +599,8 @@ challenges:
     1. Create a fork of the following GitHub repo, which contains a Sentinel Policy Set that you can use in your own organization. As you did with the hashicat-gcp repo, use the **Fork** button in the upper right corner of the screen to create your own copy.
 
     https://github.com/hashicorp/tfc-workshops-sentinel
+
+    **Note:**: If you previously forked this repository before 9/20/2020, please delete your fork and re-fork it to ensure that you are using newer versions of the policies that use the Sentinel v2 imports.
 
     Before moving on, please look at the [enforce-mandatory-labels](https://github.com/hashicorp/tfc-workshops-sentinel/blob/master/gcp/enforce-mandatory-labels.sentinel) policy. This policy requires all Google Compute Instances to have `department` and `billable` labels. It uses some functions from a Sentinel module in a different repository called [terraform-guides](https://github.com/hashicorp/terraform-guides). You'll find many useful Sentinel policies and functions in its [governance/third-generation](https://github.com/hashicorp/terraform-guides/tree/master/governance/third-generation) directory.
 

--- a/instruqt-tracks/terraform-intro-aws/track.yml
+++ b/instruqt-tracks/terraform-intro-aws/track.yml
@@ -1014,11 +1014,13 @@ challenges:
 
     Next you'll be prompted to create a workspace. You can skip the VCS integration step by clicking the "CLI-driven workflow" panel. Name your workspace **hashicat-aws**.
 
-    Now go into the workspace's **Settings >> General** settings page and change the Execution Mode to **Local**.
+    **Note:** If you already have a **hashicat-aws** workspace, please delete the workspace by selecting the **Settings >> Destruction and Deletion** menu, clicking the "Delete from Terraform Cloud" button, typing "hashicat-aws" to confirm, and then clicking the "Delete workspace" button. Then re-create it as above. Doing this avoids possible problems with mis-matched state versions when executing local runs after having executed remote runs. This could happen if you played the [Terraform Cloud with AWS](https://play.instruqt.com/hashicorp/tracks/terraform-cloud-aws) track and then played this track.
 
-    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match. This will avoid possible errors later in this track.
+    Now select the workspace's **Settings >> General** menu and change the Execution Mode to **Local**.
 
-    Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match.
+
+    Be sure to save your settings by clicking the "Save settings" button at the bottom of the page! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
   notes:
   - type: text
     contents: Terraform Cloud remote state storage is free for all users.

--- a/instruqt-tracks/terraform-intro-azure/track.yml
+++ b/instruqt-tracks/terraform-intro-azure/track.yml
@@ -1011,11 +1011,13 @@ challenges:
 
     Next you'll be prompted to create a workspace. You can skip the VCS integration step by clicking the "CLI-driven workflow" panel. Name your workspace **hashicat-azure**.
 
-    Now go into the workspace's **Settings >> General** settings page and change the Execution Mode to **Local**.
+    **Note:** If you already have a **hashicat-azure** workspace, please delete the workspace by selecting the **Settings >> Destruction and Deletion** menu, clicking the "Delete from Terraform Cloud" button, typing "hashicat-azure" to confirm, and then clicking the "Delete workspace" button. Then re-create it as above. Doing this avoids possible problems with mis-matched state versions when executing local runs after having executed remote runs. This could happen if you played the [Terraform Cloud with Azure](https://play.instruqt.com/hashicorp/tracks/terraform-cloud-azure) track and then played this track.
 
-    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match. This will avoid possible errors later in this track.
+    Now select the workspace's **Settings >> General** menu and change the Execution Mode to **Local**.
 
-    Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match.
+
+    Be sure to save your settings by clicking the "Save settings" button at the bottom of the page! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
   notes:
   - type: text
     contents: Terraform Cloud remote state storage is free for all users.

--- a/instruqt-tracks/terraform-intro-gcp/track.yml
+++ b/instruqt-tracks/terraform-intro-gcp/track.yml
@@ -971,11 +971,13 @@ challenges:
 
     Next you'll be prompted to create a workspace. You can skip the VCS integration step by clicking the "CLI-driven workflow" panel. Name your workspace **hashicat-gcp**.
 
-    Now go into the workspace's **Settings >> General** settings page and change the Execution Mode to **Local**.
+    **Note:** If you already have a **hashicat-gcp** workspace, please delete the workspace by selecting the **Settings >> Destruction and Deletion** menu, clicking the "Delete from Terraform Cloud" button, typing "hashicat-gcp" to confirm, and then clicking the "Delete workspace" button. Then re-create it as above. Doing this avoids possible problems with mis-matched state versions when executing local runs after having executed remote runs. This could happen if you played the [Terraform Cloud with GCP](https://play.instruqt.com/hashicorp/tracks/terraform-cloud-gcp) track and then played this track.
 
-    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match. This will avoid possible errors later in this track.
+    Now select the workspace's **Settings >> General** menu and change the Execution Mode to **Local**.
 
-    Be sure to save your settings! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match.
+
+    Be sure to save your settings by clicking the "Save settings" button at the bottom of the page! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
   notes:
   - type: text
     contents: Terraform Cloud remote state storage is free for all users.


### PR DESCRIPTION
We want users to refork the hashicat-* repos and the tfc-workshops-sentinel repo if they have already forked them.  Doing this ensures they are using the right versions in their initial states.

We also want them to recreate existing hashicat-* workspaces to avoid possible state mismatch errors.