### PR TITLE
Update aws_intro_to_terraform_INSTRUCTOR_GUIDE.md

### DIFF
--- a/instructor-guides/aws_intro_to_terraform_INSTRUCTOR_GUIDE.md
+++ b/instructor-guides/aws_intro_to_terraform_INSTRUCTOR_GUIDE.md
@@ -69,7 +69,7 @@ https://github.com/hashicorp/field-workshops-terraform/issues
 ### Hands-on Labs
 At certain points in the slide deck there are links to the lab exercises. [Instruqt](https://instruqt.com/hashicorp) is our lab platform. Lab exercises can be completed anonymously, but if users want to keep track of their progress they should create accounts on the Instruqt website. There is one long instruqt track that is broken into sections for the labs:
 
-https://instruqt.com/hashicorp/tracks/terraform-build-aws
+https://play.instruqt.com/hashicorp/tracks/terraform-intro-aws
 
 Go through this track start to finish and make sure you understand all the challenges. Students may have questions during the labs. When presenting a workshop be sure to give enough time for all your participants to go through the labs. Remember that this is probably their first time working a tool like Terraform.
 


### PR DESCRIPTION
the URL previously was https://instruqt.com/hashicorp/tracks/terraform-build-aws, takes to you a 404.  Updated to the new URL.