### PR TITLE
Terraform Version not supported for Local Exec

### DIFF
--- a/instruqt-tracks/terraform-cloud-aws/track.yml
+++ b/instruqt-tracks/terraform-cloud-aws/track.yml
@@ -115,10 +115,6 @@ challenges:
 
     Go into the workspace's **Settings >> General** settings page and change the **Execution Mode** to **Local**.
 
-    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match.
-
-    Be sure to save your settings by clicking the "Save settings" button at the bottom of the page! This will allow us to run Terraform commands from our workstation with local variables.
-
     Enable a free 30 day trial of Terraform Cloud's "Team & Governance" plan by navigating to your project's **Settings** menu and then to **Plan & Billing**, select **Change Plan**, select the "Trial Plan" radio button, and click the "Start your ree trial" button.
 
     Or, if you have an existing account where you've already used a trial, provide your instructor with your organization's name. They will upgrade your organization to unlock a 30 day free trial of all paid features.


### PR DESCRIPTION
In the TFC UI when the execution mode is set to "Local", the terraform version cannot be set as per the Instruct instructions. Hence the language in Instruqt is being updated.