### PR TITLE
set tf version before local execution

### DIFF
--- a/instruqt-tracks/terraform-cloud-aws/track.yml
+++ b/instruqt-tracks/terraform-cloud-aws/track.yml
@@ -113,9 +113,9 @@ challenges:
 
     DO NOT SKIP THIS NEXT STEP:
 
-    Go into the workspace's **Settings >> General** settings page and change the **Execution Mode** to **Local**.
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match on the workspace's **Settings >> General** settings page.
 
-    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match.
+    Also, change the **Execution Mode** to **Local**.
 
     Be sure to save your settings by clicking the "Save settings" button at the bottom of the page! This will allow us to run Terraform commands from our workstation with local variables.
 

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -113,9 +113,9 @@ challenges:
 
     DO NOT SKIP THIS NEXT STEP:
 
-    Go into the workspace's **Settings >> General** settings page and change the **Execution Mode** to **Local**.
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match on the workspace's **Settings >> General** settings page.
 
-    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match.
+    Also, change the **Execution Mode** to **Local**.
 
     Be sure to save your settings by clicking the "Save settings" button at the bottom of the page! This will allow us to run Terraform commands from our workstation with local variables.
 

--- a/instruqt-tracks/terraform-cloud-gcp/track.yml
+++ b/instruqt-tracks/terraform-cloud-gcp/track.yml
@@ -115,9 +115,9 @@ challenges:
 
     DO NOT SKIP THIS NEXT STEP:
 
-    Go into the workspace's **Settings >> General** settings page and change the **Execution Mode** to **Local**.
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match on the workspace's **Settings >> General** settings page.
 
-    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match.
+    Also, change the **Execution Mode** to **Local**.
 
     Be sure to save your settings by clicking the "Save settings" button at the bottom of the page! This will allow us to run Terraform commands from our workstation with local variables.
 

--- a/instruqt-tracks/terraform-intro-aws/track.yml
+++ b/instruqt-tracks/terraform-intro-aws/track.yml
@@ -1016,9 +1016,9 @@ challenges:
 
     **Note:** If you already have a **hashicat-aws** workspace, please delete the workspace by selecting the **Settings >> Destruction and Deletion** menu, clicking the "Delete from Terraform Cloud" button, typing "hashicat-aws" to confirm, and then clicking the "Delete workspace" button. Then re-create it as above. Doing this avoids possible problems with mis-matched state versions when executing local runs after having executed remote runs. This could happen if you played the [Terraform Cloud with AWS](https://play.instruqt.com/hashicorp/tracks/terraform-cloud-aws) track and then played this track.
 
-    Now select the workspace's **Settings >> General** menu and change the Execution Mode to **Local**.
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match on the workspace's **Settings >> General** settings page.
 
-    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match.
+    Also, change the **Execution Mode** to **Local**.
 
     Be sure to save your settings by clicking the "Save settings" button at the bottom of the page! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
   notes:

--- a/instruqt-tracks/terraform-intro-azure/track.yml
+++ b/instruqt-tracks/terraform-intro-azure/track.yml
@@ -1013,9 +1013,9 @@ challenges:
 
     **Note:** If you already have a **hashicat-azure** workspace, please delete the workspace by selecting the **Settings >> Destruction and Deletion** menu, clicking the "Delete from Terraform Cloud" button, typing "hashicat-azure" to confirm, and then clicking the "Delete workspace" button. Then re-create it as above. Doing this avoids possible problems with mis-matched state versions when executing local runs after having executed remote runs. This could happen if you played the [Terraform Cloud with Azure](https://play.instruqt.com/hashicorp/tracks/terraform-cloud-azure) track and then played this track.
 
-    Now select the workspace's **Settings >> General** menu and change the Execution Mode to **Local**.
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match on the workspace's **Settings >> General** settings page.
 
-    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match.
+    Also, change the **Execution Mode** to **Local**.
 
     Be sure to save your settings by clicking the "Save settings" button at the bottom of the page! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
   notes:

--- a/instruqt-tracks/terraform-intro-gcp/track.yml
+++ b/instruqt-tracks/terraform-intro-gcp/track.yml
@@ -973,9 +973,9 @@ challenges:
 
     **Note:** If you already have a **hashicat-gcp** workspace, please delete the workspace by selecting the **Settings >> Destruction and Deletion** menu, clicking the "Delete from Terraform Cloud" button, typing "hashicat-gcp" to confirm, and then clicking the "Delete workspace" button. Then re-create it as above. Doing this avoids possible problems with mis-matched state versions when executing local runs after having executed remote runs. This could happen if you played the [Terraform Cloud with GCP](https://play.instruqt.com/hashicorp/tracks/terraform-cloud-gcp) track and then played this track.
 
-    Now select the workspace's **Settings >> General** menu and change the Execution Mode to **Local**.
+    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match on the workspace's **Settings >> General** settings page.
 
-    Run `terraform version` on the "Shell" tab and then set the **Terraform Version** to match.
+    Also, change the **Execution Mode** to **Local**.
 
     Be sure to save your settings by clicking the "Save settings" button at the bottom of the page! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
   notes:


### PR DESCRIPTION
This addresses a problem that @pmnathan pointed out which is that TFC does not let you set the Terraform version after setting execution mode to local.  I have changed the order so that the participant is first told to set the Terraform version and then to set execution mode to local.  I have tested that the single click of the Save button will save the Terraform version even though the version is not visible at the time of the Save.

Logically, it would have made more sense to have the student set the Terraform version later when they switch to execution mode, but it is easier to set both settings at once.