### PR TITLE
fix code-server service file

### DIFF
--- a/instruqt-tracks/terraform-cloud-bonus-lab/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-bonus-lab/setup-our-environment/setup-workstation
@@ -6,6 +6,8 @@ set -e
 # Allow instruqt time to do its thing
 sleep 10
 
+set-workdir /root
+
 # Create VSC startup script
 cat <<-EOF > /etc/systemd/system/code-server.service
 [Unit]
@@ -18,7 +20,7 @@ Type=simple
 Restart=always
 RestartSec=1
 User=root
-ExecStart=/usr/bin/code-server --host 0.0.0.0 --port 8443 --cert --auth none \$(pwd)
+ExecStart=/usr/bin/code-server --host 0.0.0.0 --port 8443 --cert --auth none /root
 
 [Install]
 WantedBy=multi-user.target

--- a/instruqt-tracks/terraform-cloud-bonus-lab/track.yml
+++ b/instruqt-tracks/terraform-cloud-bonus-lab/track.yml
@@ -4,8 +4,10 @@ type: track
 title: Bonus Lab - Terraform Cloud
 teaser: |
   Ready for more? Test your Terraform Cloud skills with this intermediate level lab challenge.
-description: |-
-  If you've completed one of the Terraform Cloud tracks and would like an extra challenge, try this bonus lab. In this track you'll build an approval pipeline and development branch for your Terraform code, then ensure that all tests pass in a dev environment before approving the change to production.
+description: If you've completed one of the Terraform Cloud tracks and would like
+  an extra challenge, try this bonus lab. In this track you'll build an approval pipeline
+  and development branch for your Terraform code, then ensure that all tests pass
+  in a dev environment before approving the change to production.
 icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/terraform.png
 tags:
 - terraform
@@ -111,4 +113,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 7200
-checksum: "2983228259820797752"
+checksum: "10461104640924123561"


### PR DESCRIPTION
The code-server service definition file for the bonus lab had startup command `/usr/bin/code-server --host 0.0.0.0 --port 8443 --cert --auth none $(pwd)`, but this was not working.  I changed `$(pwd)` to `/root` and it now works.