### PR TITLE
update intro to TF for AWS

### DIFF
--- a/instruqt-tracks/terraform-intro-aws/add-a-tag/solve-workstation
+++ b/instruqt-tracks/terraform-intro-aws/add-a-tag/solve-workstation
@@ -6,6 +6,7 @@ set -o history
 
 cd /root/hashicat-aws
 
-sed -i '11 a \ \ \ \ environment = "Production"' main.tf
+# sed -i '19 a \ \ \ \ environment = "Production"' main.tf
+sed -i 's/name = "\${var\.prefix}-vpc-\${var\.region}"/name = "\${var.prefix}-vpc-\${var.region}"\n    environment = "Production"/' main.tf
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/add-an-output/solve-workstation
+++ b/instruqt-tracks/terraform-intro-aws/add-an-output/solve-workstation
@@ -10,7 +10,7 @@ cd /root/hashicat-aws
 cat <<-EOF >> outputs.tf
 
 output "catapp_ip" {
-  value = aws_eip.hashicat.public_ip
+  value = "http://\${aws_eip.hashicat.public_ip}"
 }
 EOF
 

--- a/instruqt-tracks/terraform-intro-aws/config.yml
+++ b/instruqt-tracks/terraform-intro-aws/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: workstation
-  image: instruqt-hashicorp/terraform-workstation-3-5-0
+  image: instruqt-hashicorp/terraform-workstation-0-14-9
   shell: /bin/bash -l
   machine_type: n1-standard-1
 aws_accounts:

--- a/instruqt-tracks/terraform-intro-aws/track.yml
+++ b/instruqt-tracks/terraform-intro-aws/track.yml
@@ -28,30 +28,6 @@ challenges:
   title: "\U0001F3E1 Moving in - Set Up Your Workspace"
   teaser: |
     Configure your code editor with the Terraform extension and open a workspace.
-  assignment: |-
-    Open the Code Editor tab on the left. First get familiar with the menus. This is running the Visual Studio Code editor. You can also use the simpler "Text Editor" tab if you prefer.
-
-    If you do use the VS Code Editor, please perform the following steps:
-
-    Notice the menu bar with File, Edit, and other menus at the top of the VS Code Editor. You can find all the menus on this menu bar.
-
-    You should see some files in the explorer bar on the left side menu. These are terraform config files for the hashicat application. Open file called "main.tf.
-
-    Next you should install the HashiCorp Terraform extension to enable syntax highlighting in your code. Click on the extensions icon - it looks like four small boxes with one slightly out of position.
-
-    Search for **HashiCorp** and select the "HashiCorp Terraform 2.x.y" extension. Click the green **Install** button to install the extension. Then click the **Reload Required** button to activate it. Then click the icon with two pages under the File menu so you can see your Terraform files again.
-
-    You will see a popup saying that some version of terraform-ls has been installed. This is referring to the "Terraform Language Server" which is used by the HashiCorp Terraform extension. Just click the "x" in the popup to close it.
-
-    We have enabled auto-save in your Code Editor, so any changes you make will be saved as you type. You don't have to worry about saving files manually.
-
-    We recommend executing all commands on the "Shell" tab. But you can also open and use a terminal window at the bottom of the Visual Code Editor by using the Terminal > New Terminal menu or the **<ctrl>-`** shortcut.
-
-    If you do use the VS Code terminal, you can toggle its size up and down with the `^` and inverted `^` buttons above it. You can get rid of it with the garbage can and `x` icons.
-
-    Congratulations, you are ready to start working with Terraform on AWS. We'll use the hashicat-aws example app in the rest of the challenges as you learn new Terraform skills.
-
-    Click the **Check** button to continue.
   notes:
   - type: text
     contents: |
@@ -64,6 +40,28 @@ challenges:
     contents: The Terraform language is designed to be both human and machine-readable.
   - type: text
     contents: Most modern text editors support Terraform syntax highlighting.
+  assignment: |-
+    Open the Code Editor tab on the left. First get familiar with the menus. This is running the Visual Studio Code editor. You can also use the simpler "Text Editor" tab if you prefer.
+
+    If you do use the VS Code Editor, please perform the following steps:
+
+    Notice the menu bar with File, Edit, and other menus at the top of the VS Code Editor. You can find all the menus on this menu bar.
+
+    You should see some files in the explorer bar on the left side menu. These are terraform config files for the hashicat application. Open file called "main.tf.
+
+    Next you should install the HashiCorp Terraform extension to enable syntax highlighting in your code. Click on the extensions icon - it looks like four small boxes with one slightly out of position.
+
+    Search for **HashiCorp** and select the "HashiCorp Terraform 2.x.y" extension. Click the blue **Install** or blue **Install in Remote** button to install the extension. Then click the icon with two pages under the File menu so you can see your Terraform files again.
+
+    We have enabled auto-save in your Code Editor, so any changes you make will be saved as you type. You don't have to worry about saving files manually.
+
+    We recommend executing all commands on the "Shell" tab. But you can also open and use a terminal window at the bottom of the Visual Code Editor by using the Terminal > New Terminal menu or the **<ctrl>-`** shortcut.
+
+    If you do use the VS Code terminal, you can toggle its size up and down with the `^` and inverted `^` buttons above it. You can get rid of it with the garbage can and `x` icons.
+
+    Congratulations, you are ready to start working with Terraform on AWS. We'll use the hashicat-aws example app in the rest of the challenges as you learn new Terraform skills.
+
+    Click the **Check** button to continue.
   tabs:
   - title: Code Editor
     type: service
@@ -84,6 +82,21 @@ challenges:
   title: "\U0001F44B Getting to Know Terraform"
   teaser: |
     Learn Terraform basics and command line syntax.
+  notes:
+  - type: text
+    contents: |-
+      Terraform open source is a command line application that you can download and run from your laptop or virtual workstation.
+
+      It is written in Go and runs on macOS, Linux or Windows. You can always download the latest version of Terraform from https://www.terraform.io/downloads.html
+  - type: text
+    contents: |-
+      Installing Terraform on your laptop or workstation is easy. You simply download the zip file, unpack it, and place it somewhere in your PATH.
+
+      Check out this tutorial for step-by-step instructions:
+
+      https://learn.hashicorp.com/terraform/getting-started/install.html
+
+      We've pre-installed Terraform in your Instruqt lab environment for you.
   assignment: |-
     Let's start with some basic Terraform commands.
     Run the following commands in the "Shell" tab or in a terminal in the VS Code editor.
@@ -103,21 +116,6 @@ challenges:
     Terraform runs on Windows, OSX, or Linux. You can install it on your laptop or on a cloud based workstation.
 
     Today we'll be using the preconfigured Terraform workstation on the left for all our lab exercises.
-  notes:
-  - type: text
-    contents: |-
-      Terraform open source is a command line application that you can download and run from your laptop or virtual workstation.
-
-      It is written in Go and runs on macOS, Linux or Windows. You can always download the latest version of Terraform from https://www.terraform.io/downloads.html
-  - type: text
-    contents: |-
-      Installing Terraform on your laptop or workstation is easy. You simply download the zip file, unpack it, and place it somewhere in your PATH.
-
-      Check out this tutorial for step-by-step instructions:
-
-      https://learn.hashicorp.com/terraform/getting-started/install.html
-
-      We've pre-installed Terraform in your Instruqt lab environment for you.
   tabs:
   - title: Code Editor
     type: service
@@ -138,6 +136,9 @@ challenges:
   title: "\U0001F510 Connecting Terraform to AWS"
   teaser: |
     Connecting to AWS with Access Keys and Secret Keys.
+  notes:
+  - type: text
+    contents: Did you know HCL stands for "HashiCorp Configuration Language"?
   assignment: |-
     In order to authenticate to AWS and build resources, Terraform requires you to provide a set of credentials, backed by an appropriate IAM policy.
 
@@ -151,9 +152,6 @@ challenges:
     ```
 
     *Do not ever store your credentials in source code files*, as they can be accidentally exposed or copied to a public repository.
-  notes:
-  - type: text
-    contents: Did you know HCL stands for "HashiCorp Configuration Language"?
   tabs:
   - title: Code Editor
     type: service
@@ -174,6 +172,14 @@ challenges:
   title: "\U0001F468‍\U0001F4BB What does Terraform code look like?"
   teaser: |
     The Terraform DSL (Domain Specific Language) is a declarative language that lets you build almost any type of infrastructure.
+  notes:
+  - type: text
+    contents: |-
+      Terraform will read anything in the current directory that ends in `*.tf` or `*.tfvars`.
+
+      By convention most Terraform workspaces will contain `main.tf`, `variables.tf`, and `outputs.tf` files.
+
+      You can also group your Terraform code into files by purpose. For example, you might place all your load balancer configuration code into a file called `load_balancer.tf`.
   assignment: |-
     We've downloaded some Terraform code onto your workstation. Run the following command to see the Terraform code files:
       ```
@@ -188,14 +194,6 @@ challenges:
       **outputs.tf** - This file contains outputs that will be shown at the end of a successful Terraform run.
 
       Files that end in anything other than `*.tf` or `*.tfvars` are ignored by Terraform.
-  notes:
-  - type: text
-    contents: |-
-      Terraform will read anything in the current directory that ends in `*.tf` or `*.tfvars`.
-
-      By convention most Terraform workspaces will contain `main.tf`, `variables.tf`, and `outputs.tf` files.
-
-      You can also group your Terraform code into files by purpose. For example, you might place all your load balancer configuration code into a file called `load_balancer.tf`.
   tabs:
   - title: Code Editor
     type: service
@@ -216,6 +214,14 @@ challenges:
   title: "\U0001F3E1 Terraform Init - Install the Providers"
   teaser: |
     Terraform needs a provider to talk to cloud APIs. The provider is the bridge that connects Terraform core to your infrastructure providers.
+  notes:
+  - type: text
+    contents: |-
+      The Terraform core program isn't very useful by itself. Terraform needs the help of a *provider* to be able to talk to cloud APIs. Terraform has hundreds of different providers. You can browse the provider list here:
+
+      https://registry.terraform.io/browse/providers
+
+      Today we'll be using a few different providers, but the main one is the *aws* provider.
   assignment: |-
     We have downloaded some Terraform code for the HashiCat application. We'll be using this source code for the rest of the track.
 
@@ -226,21 +232,13 @@ challenges:
 
     The `terraform init` command scans your Terraform code, identifies any providers that are needed, and downloads them.
 
-    Run the following command to take a peek inside the `.terraform` directory:
+    Run the following command to verify that the aws provider was installed under the ".terraform" directory:
 
     ```
-    ls .terraform/plugins
+    ls .terraform/providers/registry.terraform.io/hashicorp
     ```
 
     This hidden directory is where all modules and plugins are stored.
-  notes:
-  - type: text
-    contents: |-
-      The Terraform core program isn't very useful by itself. Terraform needs the help of a *provider* to be able to talk to cloud APIs. Terraform has hundreds of different providers. You can browse the provider list here:
-
-      https://www.terraform.io/docs/providers/index.html
-
-      Today we'll be using a few different providers, but the main one is the *aws* provider.
   tabs:
   - title: Code Editor
     type: service
@@ -261,12 +259,12 @@ challenges:
   title: "\U0001F4DD Quiz 1 - Providers and Modules"
   teaser: |
     A quiz about Terraform init
-  assignment: |
-    Where does Terraform store its modules and providers?
   notes:
   - type: text
     contents: |
       It's quiz time!
+  assignment: |
+    Where does Terraform store its modules and providers?
   answers:
   - In the /tmp directory
   - In the user's home directory
@@ -282,12 +280,16 @@ challenges:
   title: "\U0001F469‍⚖️ Terraform Validate - Test Your Code"
   teaser: |
     Terraform has a built in validation tester. This is useful to see whether your Terraform code is valid and parses correctly.
+  notes:
+  - type: text
+    contents: Terraform has a built-in syntax checker. You can run it with the `terraform
+      validate` command.
   assignment: |-
     Terraform comes with a built-in subcommand called *validate*. This is useful when you want to do a quick syntax check of your code to make sure it parses correctly.
 
     Click on the File Explorer icon on the left. It looks like a stack of papers.
 
-    Edit the main.tf file and remove the double quotes between `aws_vpc` and `hashicat` on line 6 of the file, keeping the space that was between them.
+    Edit the main.tf file and remove the double quotes between `aws_vpc` and `hashicat` on line 14 of the file, keeping the space that was between them.
 
     Validate your code:
 
@@ -295,13 +297,9 @@ challenges:
     terraform validate
     ```
 
-    Now put the double quotes back in line 6 and run the validate command again. This time you should pass the validation test.
+    Now put the double quotes back in line 14 and run the validate command again. This time you should pass the validation test.
 
     `terraform validate` is most often used in automated CI/CD test pipelines. It allows you to quickly catch errors in your code before any other steps are taken.
-  notes:
-  - type: text
-    contents: Terraform has a built-in syntax checker. You can run it with the `terraform
-      validate` command.
   tabs:
   - title: Code Editor
     type: service
@@ -322,6 +320,12 @@ challenges:
   title: "\U0001F914 Terraform Plan - Dry Run Mode"
   teaser: |
     Terraform has a dry run mode where you can preview what will be built without actually creating any resources. In this challenge we'll run `terraform plan` and view the output.
+  notes:
+  - type: text
+    contents: |-
+      `terraform plan` allows you to preview any changes to your environment in a safe way.
+
+      This can help you identify any unexpected changes before you deploy them, not after they are already built.
   assignment: |-
     Run the `terraform plan` command:
 
@@ -334,12 +338,6 @@ challenges:
     Enter a short string of lower-case letters and/or numbers. We recommend that you use your first and last name.
 
     The prefix will become part of the name for our VPC, subnet, EC2 instance and other resources.
-  notes:
-  - type: text
-    contents: |-
-      `terraform plan` allows you to preview any changes to your environment in a safe way.
-
-      This can help you identify any unexpected changes before you deploy them, not after they are already built.
   tabs:
   - title: Code Editor
     type: service
@@ -360,16 +358,16 @@ challenges:
   title: "\U0001F39B️ Working with Terraform Variables"
   teaser: |
     Terraform variables allow you to customize your infrastructure without editing any code. You can use the same Terraform code to deploy dev, staging and production but with different variables.
+  notes:
+  - type: text
+    contents: The `terraform.tfvars` file is a convenient place for users to configure
+      their variables.
   assignment: |-
     In Terraform all variables must be declared (with or without an optional default value) before you can use them. Variables are usually declared in the "variables.tf" file although they can also be declared in other "*.tf" files. Their values can be set in the "terraform.tfvars" file and in other ways which we'll explore later.
 
     Open the "terraform.tfvars" file and set your `prefix` variable by deleting the `# ` at the beginning of the line and replacing "yourname" with your own name (first and last with or without a hyphen between them and all lower case).
 
     Now run `terraform plan` again. This time you won't have to enter your prefix manually.
-  notes:
-  - type: text
-    contents: The `terraform.tfvars` file is a convenient place for users to configure
-      their variables.
   tabs:
   - title: Code Editor
     type: service
@@ -390,6 +388,12 @@ challenges:
   title: "\U0001F5FC Change Your Location"
   teaser: |
     Terraform is flexible enough to deploy infrastructure anywhere in the world. You can easily provision your applications in different geographical regions by simply changing a single variable.
+  notes:
+  - type: text
+    contents: |-
+      You can override any variable defined in the "variables.tf" file by setting it in your personal `terraform.tfvars` file.
+
+      In this challenge, you will pick the location where your AWS resources should be deployed.
   assignment: |-
     In the previous challenge we set our `prefix` variable in the "terraform.tfvars" file. Let's set another variable that will determine the location where your AWS infrastructure will be deployed.
 
@@ -408,12 +412,6 @@ challenges:
     Once you've set your `region` variable, try running `terraform plan` again. What's different this time?
 
     Remember that you can set values for any variable declared in your "variables.tf" file in the "terraform.tfvars" file.
-  notes:
-  - type: text
-    contents: |-
-      You can override any variable defined in the "variables.tf" file by setting it in your personal `terraform.tfvars` file.
-
-      In this challenge, you will pick the location where your AWS resources should be deployed.
   tabs:
   - title: Code Editor
     type: service
@@ -434,12 +432,12 @@ challenges:
   title: "\U0001F4DD Quiz 2 - Variables"
   teaser: |
     A quiz about Terraform variables
-  assignment: |
-    Where are terraform variables *declared*?
   notes:
   - type: text
     contents: |
       Another quiz, get ready!
+  assignment: |
+    Where are terraform variables *declared*?
   answers:
   - On the command line
   - As environment variables
@@ -455,6 +453,11 @@ challenges:
   title: "\U0001F4C8 Terraform Graph"
   teaser: |
     Terraform creates a graph of all the infrastructure defined in your code.
+  notes:
+  - type: text
+    contents: Terraform Graph can provide a visual representation of all your infrastructure.
+      This is handy for finding dependency issues or resources that will be affected
+      by a change.
   assignment: |-
     Try running the `terraform graph` command:
 
@@ -479,11 +482,6 @@ challenges:
     **NOTE:** Due to a known bug you may not be able to drag and zoom the graph. The main point of this exercise is to see how terraform maps out complex infrastructure. So don't worry if your graph doesn't show color.
 
     Terraform uses this graph to determine which resources can be built in parallel for maximum efficiency.
-  notes:
-  - type: text
-    contents: Terraform Graph can provide a visual representation of all your infrastructure.
-      This is handy for finding dependency issues or resources that will be affected
-      by a change.
   tabs:
   - title: Command Line
     type: terminal
@@ -500,6 +498,12 @@ challenges:
   title: "\U0001F468‍\U0001F4BB Terraform Plan and Terraform Apply"
   teaser: |
     The `terraform plan` command can be run anytime to get a preview of changes that Terraform might make. When you run Terraform apply these changes are implemented, and Terraform builds, updates, or destroys resources.
+  notes:
+  - type: text
+    contents: |-
+      By default, the `terraform apply` command runs a Terraform plan to show you what changes it wants to make.
+
+      Terraform maps out all the changes it needs to make before applying them.
   assignment: |-
     Now that we've configured our required variables we can apply our changes.
 
@@ -519,12 +523,6 @@ challenges:
     You'll need to enter **yes** when Terraform prompts you with the "Do you want to perform these actions?" question.
 
     Right now our code only defines a VPC. We'll be building upon this starting point in the next challenge.
-  notes:
-  - type: text
-    contents: |-
-      By default, the `terraform apply` command runs a Terraform plan to show you what changes it wants to make.
-
-      Terraform maps out all the changes it needs to make before applying them.
   tabs:
   - title: Code Editor
     type: service
@@ -545,6 +543,14 @@ challenges:
   title: "\U0001F469‍\U0001F4BB Test and Repair"
   teaser: |
     Terraform is idempotent. Each resource in your code will be examined, and if it already exists Terraform will leave it alone.
+  notes:
+  - type: text
+    contents: |-
+      Terraform is an *idempotent* application.
+
+      Idempotence is the property of certain operations in mathematics and computer science whereby they can be applied multiple times without changing the result beyond the initial application.
+
+      https://en.wikipedia.org/wiki/Idempotence
   assignment: |-
     Try running `terraform plan` again and see what happens:
 
@@ -563,14 +569,6 @@ challenges:
     ```
 
     Terraform checks each resource to ensure it is in the proper state. It will not re-create your VPC if it is already provisioned correctly.
-  notes:
-  - type: text
-    contents: |-
-      Terraform is an *idempotent* application.
-
-      Idempotence is the property of certain operations in mathematics and computer science whereby they can be applied multiple times without changing the result beyond the initial application.
-
-      https://en.wikipedia.org/wiki/Idempotence
   tabs:
   - title: Code Editor
     type: service
@@ -591,6 +589,12 @@ challenges:
   title: "\U0001F6EB Change Your Prefix"
   teaser: |
     When your Terraform code changes, your infrastructure will be modified to match the updated code. Terraform is a declarative language.
+  notes:
+  - type: text
+    contents: |-
+      Terraform can create, destroy, update in place, or destroy and re-create your infrastructure. Some types of resources can be updated without deleting them. Major changes usually require a teardown and rebuild.
+
+      Terraform always tries to match the current infrastructure to what has been defined in your code.
   assignment: |-
     Edit the `terraform.tfvars` file to change your prefix. You could simply add a number to the end if you like. Or change it to something entirely new.
 
@@ -603,12 +607,6 @@ challenges:
     Type "yes" when prompted.
 
     Observe the output. What happened?
-  notes:
-  - type: text
-    contents: |-
-      Terraform can create, destroy, update in place, or destroy and re-create your infrastructure. Some types of resources can be updated without deleting them. Major changes usually require a teardown and rebuild.
-
-      Terraform always tries to match the current infrastructure to what has been defined in your code.
   tabs:
   - title: Code Editor
     type: service
@@ -629,6 +627,10 @@ challenges:
   title: "\U0001F3F7️ Add a Tag to Your VPC"
   teaser: |
     Terraform can change some resources in in place without deleting them. Adding tags is a non-destructive action.
+  notes:
+  - type: text
+    contents: Adding, changing, or removing tags is a non-destructive action. Terraform
+      can tag your resources without re-creating them.
   assignment: |-
     Several resource types support AWS's tags. Read the Terraform documentation for the `aws_vpc` resource to learn about the `tags` argument and its format.
 
@@ -641,10 +643,6 @@ challenges:
     Re-run `terraform apply`.
 
     What happens?
-  notes:
-  - type: text
-    contents: Adding, changing, or removing tags is a non-destructive action. Terraform
-      can tag your resources without re-creating them.
   tabs:
   - title: Code Editor
     type: service
@@ -665,6 +663,10 @@ challenges:
   title: "\U0001F5A7 Add a Virtual Network"
   teaser: |
     Terraform resources are like building blocks. You can continue adding more blocks until your infrastructure reaches the desired state.
+  notes:
+  - type: text
+    contents: Terraform code can be built incrementally, one or two resources at a
+      time.
   assignment: |-
     Open the **main.tf** file again and uncomment the next resource block in the file. The type of resource is **aws_subnet** and it is named **hashicat**.
 
@@ -675,10 +677,6 @@ challenges:
     Look at the **vpc_id** parameter inside the aws_subnet resource. See how it points back at the first resource in the file? The subnet resource inherits settings from the VPC.
 
     Terraform can map out the complex web of dependencies between hundreds of interconnected resources.
-  notes:
-  - type: text
-    contents: Terraform code can be built incrementally, one or two resources at a
-      time.
   tabs:
   - title: Code Editor
     type: service
@@ -699,6 +697,10 @@ challenges:
   title: "\U0001F3D7️ Complete the Build"
   teaser: |
     Terraform code can stand up everything from VPCs, to virtual networks, to VMs and containers.
+  notes:
+  - type: text
+    contents: The `-auto-approve` flag can be used to override the "Are you sure?"
+      questions that appear before an apply or destroy. Use with caution!
   assignment: |-
     We've uncommented all the rest of the Terraform code in the **main.tf** file for you. Run a `terraform plan` to see what will be built:
 
@@ -717,10 +719,6 @@ challenges:
     If the application won't load just run `terraform apply` again. This will attempt to reinstall the webserver and start your application if it's not running.
 
     Open your web application in a new browser tab. You'll need to copy and paste the URL into your address bar.
-  notes:
-  - type: text
-    contents: The `-auto-approve` flag can be used to override the "Are you sure?"
-      questions that appear before an apply or destroy. Use with caution!
   tabs:
   - title: Code Editor
     type: service
@@ -741,6 +739,9 @@ challenges:
   title: "\U0001F4C8 Terraform Graph"
   teaser: |
     Revisit graph to see what has changed.
+  notes:
+  - type: text
+    contents: Let's revisit our graph to see what has changed.
   assignment: |-
     Start up a Blast Radius server with the following command:
 
@@ -755,9 +756,6 @@ challenges:
     **NOTE:** Due to a known bug you may not be able to drag and zoom the graph. The main point of this exercise is to see how terraform maps out complex infrastructure. So don't worry if your graph doesn't show color.
 
     Terraform uses this graph to determine which resources can be built in parallel for maximum efficiency.
-  notes:
-  - type: text
-    contents: Let's revisit our graph to see what has changed.
   tabs:
   - title: Command Line
     type: terminal
@@ -774,12 +772,12 @@ challenges:
   title: "\U0001F4DD Quiz 3 - Terraform Apply"
   teaser: |
     What happens when you run `terraform apply` without a plan file?
-  assignment: |
-    What happens when you run `terraform apply` without specifying a plan file?
   notes:
   - type: text
     contents: |
       It's quiz time!
+  assignment: |
+    What happens when you run `terraform apply` without specifying a plan file?
   answers:
   - Terraform runs without any plan
   - Terraform reads the previous plan and then applies it
@@ -795,27 +793,6 @@ challenges:
   title: "\U0001F6E0️ Use a Provisioner"
   teaser: |
     Terraform works great with many different provisioning tools including Chef, Puppet, Ansible, Bash, and Powershell.
-  assignment: |-
-    Open the `main.tf` file in the Code Editor. Scroll down until you find the `remote-exec` provisioner block, or search the file and find it with CTRL-F.
-
-    Add the following two lines at the end of the inline list of commands:
-
-    ```
-    "sudo apt -y install cowsay",
-    "cowsay Mooooooooooo!",
-    ```
-
-    After copying them into your buffer, it will be easier to paste them if you hide the assignment by clicking the icon that looks like a picture frame next to the circular refresh icon. Click it again to redisplay the assignment.
-
-    This might be a good time to use the `terraform fmt` command to line up the commands nicely.
-
-    Now run another `terraform apply -auto-approve` to apply your changes:
-
-    ```
-    terraform apply -auto-approve
-    ```
-
-    Scroll back through the log output. You should see an ASCII art cow saying "Moooooooo!"
   notes:
   - type: text
     contents: Terraform provisioners run once at creation time. They do not run on
@@ -838,6 +815,27 @@ challenges:
                        ||     ||
       =============================
       ```
+  assignment: |-
+    Open the `main.tf` file in the Code Editor. Scroll down until you find the `remote-exec` provisioner block, or search the file and find it with CTRL-F.
+
+    Add the following two lines at the end of the inline list of commands:
+
+    ```
+    "sudo apt -y install cowsay",
+    "cowsay Mooooooooooo!",
+    ```
+
+    After copying them into your buffer, it will be easier to paste them if you hide the assignment by clicking the icon that looks like a picture frame next to the circular refresh icon. Click it again to redisplay the assignment.
+
+    This might be a good time to use the `terraform fmt` command to line up the commands nicely.
+
+    Now run another `terraform apply -auto-approve` to apply your changes:
+
+    ```
+    terraform apply -auto-approve
+    ```
+
+    Scroll back through the log output. You should see an ASCII art cow saying "Moooooooo!"
   tabs:
   - title: Code Editor
     type: service
@@ -858,6 +856,17 @@ challenges:
   title: "\U0001F5A8️ Add an Output"
   teaser: |
     Outputs are used to convey useful information such as IP addresses, application URLs or other useful data.
+  notes:
+  - type: text
+    contents: You can mix plain text along with Terraform data in your outputs. Outputs
+      can be used to convey useful information to your users at the end of a run.
+  - type: text
+    contents: The `terraform refresh` command will sync your state file with what
+      exists in your infrastructure. A refresh command will not change your infrastructure.
+  - type: text
+    contents: The `terraform output` command can be run any time you want to see your
+      Terraform outputs again. Run `terraform output <output_name>` to view a single
+      output.
   assignment: |-
     Open the **outputs.tf** file in the Code Editor. Note the public_dns output in the file.
 
@@ -881,17 +890,6 @@ challenges:
     ```
     terraform output
     ```
-  notes:
-  - type: text
-    contents: You can mix plain text along with Terraform data in your outputs. Outputs
-      can be used to convey useful information to your users at the end of a run.
-  - type: text
-    contents: The `terraform refresh` command will sync your state file with what
-      exists in your infrastructure. A refresh command will not change your infrastructure.
-  - type: text
-    contents: The `terraform output` command can be run any time you want to see your
-      Terraform outputs again. Run `terraform output <output_name>` to view a single
-      output.
   tabs:
   - title: Code Editor
     type: service
@@ -912,6 +910,28 @@ challenges:
   title: "\U0001F436 Fun With Variables"
   teaser: |
     Variables give the consumers of your Terraform code an easy way to customize their infrastructure.
+  notes:
+  - type: text
+    contents: |-
+      Terraform variables have five levels of precedence. 1=highest 5=lowest:
+
+      1. Command line flag - run as a command line switch
+      1. Configuration file - set in your terraform.tfvars file
+      1. Environment variable - part of your shell environment
+      1. Default Config - default value in variables.tf
+      1. User manual entry - if not specified, prompt the user for entry
+  - type: text
+    contents: |-
+      Here are some other fun placeholder sites you can try with the **placeholder** variable:
+
+      placedog.net<br>
+      placebear.com<br>
+      www.fillmurray.com<br>
+      www.placecage.com<br>
+      placebeard.it<br>
+      loremflickr.com<br>
+      baconmockup.com<br>
+      placeimg.com<br>
   assignment: |-
     There are several ways to configure Terraform variables. So far we've been using the `terraform.tfvars` file to set our variables. Try re-deploying your application with different **height** and **width** variables on the command line. Reload the webapp after each apply to observe any changes.
 
@@ -940,28 +960,6 @@ challenges:
     Which variable took precedence? Why?
 
     See this [doc](https://www.terraform.io/docs/configuration/variables.html#variable-definition-precedence) if you're unsure.
-  notes:
-  - type: text
-    contents: |-
-      Terraform variables have five levels of precedence. 1=highest 5=lowest:
-
-      1. Command line flag - run as a command line switch
-      1. Configuration file - set in your terraform.tfvars file
-      1. Environment variable - part of your shell environment
-      1. Default Config - default value in variables.tf
-      1. User manual entry - if not specified, prompt the user for entry
-  - type: text
-    contents: |-
-      Here are some other fun placeholder sites you can try with the **placeholder** variable:
-
-      placedog.net<br>
-      placebear.com<br>
-      www.fillmurray.com<br>
-      www.placecage.com<br>
-      placebeard.it<br>
-      loremflickr.com<br>
-      baconmockup.com<br>
-      placeimg.com<br>
   tabs:
   - title: Code Editor
     type: service
@@ -982,12 +980,12 @@ challenges:
   title: "\U0001F4DD Quiz 4 - Terraform Variables"
   teaser: |
     How do Terraform variables get set or overridden?
-  assignment: |
-    You have the same variable set in a *.tfvars file and as an environment variable. Which one takes precedence?
   notes:
   - type: text
     contents: |
       Get ready for another quiz...
+  assignment: |
+    You have the same variable set in a *.tfvars file and as an environment variable. Which one takes precedence?
   answers:
   - The environment variable
   - The tfvars config file
@@ -1003,6 +1001,9 @@ challenges:
   title: ☁️ Terraform Cloud Setup
   teaser: |
     Terraform Cloud offers unlimited free Terraform state storage for users. Safeguard your state files by storing them remotely in Terraform Cloud.
+  notes:
+  - type: text
+    contents: Terraform Cloud remote state storage is free for all users.
   assignment: |-
     During this challenge and the next one, you'll use the remote state feature of Terraform Cloud to store your state file in the cloud. In order to do this you'll need a Terraform Cloud account. Click on the URL below and sign up for a free account if you don't have one already:
 
@@ -1021,9 +1022,6 @@ challenges:
     Also, change the **Execution Mode** to **Local**.
 
     Be sure to save your settings by clicking the "Save settings" button at the bottom of the page! This will allow us to run Terraform commands from our workstation with local variables, which we'll do in the next challenge.
-  notes:
-  - type: text
-    contents: Terraform Cloud remote state storage is free for all users.
   tabs:
   - title: Code Editor
     type: service
@@ -1044,6 +1042,14 @@ challenges:
   title: "\U0001F39B️ Configure Remote State"
   teaser: |
     The terraform command line tool can store its state in Terraform Cloud. All that is required is a user token.
+  notes:
+  - type: text
+    contents: |-
+      With *local* execution mode the Terraform commands and variables all remain
+      on your workstation.
+
+      With *remote* execution mode Terraform runs in a Terraform Cloud
+      container environment. All variables must be configured in the cloud environment with this method.
   assignment: |-
     During this challenge we'll configure Terraform Cloud as a remote state backend, and then migrate our existing state file to Terraform Cloud.
 
@@ -1076,14 +1082,6 @@ challenges:
     Your state is now safely stored in Terraform Cloud.
 
     Run a `terraform apply -auto-approve` and watch your state file evolve with each change. You can browse through previous state files with the Terraform Cloud UI.
-  notes:
-  - type: text
-    contents: |-
-      With *local* execution mode the Terraform commands and variables all remain
-      on your workstation.
-
-      With *remote* execution mode Terraform runs in a Terraform Cloud
-      container environment. All variables must be configured in the cloud environment with this method.
   tabs:
   - title: Code Editor
     type: service
@@ -1108,6 +1106,12 @@ challenges:
   title: "\U0001F525 Terraform Destroy"
   teaser: |
     Terraform can build infrastructure and also destroy it when you are done using it. This helps control costs and reduce infrastructure sprawl.
+  notes:
+  - type: text
+    contents: |-
+      Terraform can destroy infrastructure as easily as it can build it.
+
+      Use `terraform destroy` with caution.
   assignment: |-
     Run the following command to destroy your infrastructure:
 
@@ -1118,12 +1122,6 @@ challenges:
     You'll need to type "yes" when prompted to destroy your infrastructure. This is a safety feature to help prevent accidental deletion of important resources.
 
     Wait until the destroy action has completely finished before clicking on the **Check** button.
-  notes:
-  - type: text
-    contents: |-
-      Terraform can destroy infrastructure as easily as it can build it.
-
-      Use `terraform destroy` with caution.
   tabs:
   - title: Code Editor
     type: service
@@ -1138,4 +1136,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1000
-checksum: "7447299001212280757"
+checksum: "5911171739638042422"


### PR DESCRIPTION
This updates the Intro to Terraform for AWS track to use Terraform 0.14.9.
I made updates to hashicat-aws over the weekend to support TF 0.14.9