### PR TITLE
must use GH personal access token

### DIFF
--- a/instructor-guides/all_terraform_cloud_INSTRUCTOR_GUIDE.md
+++ b/instructor-guides/all_terraform_cloud_INSTRUCTOR_GUIDE.md
@@ -129,7 +129,7 @@ Skipping for HashiCorp users is enabled through the combination of a `fastforwar
 So, if you would like to skip challenges while running one of these tracks, you should do the following:
 
 1. Run the `fastforward` script during a challenge (preferably the first). Just type `fastforward`.
-2. This script will prompt you to enter your TFC organization, the name of your TFC workspace, your TFC token, your GitHub user ID, your GitHub password or personal access token, your GitHub user name (first and last names), your GitHub email, and an OAuth ID for a VCS connection in your TFC organization.
+2. This script will prompt you to enter your TFC organization, the name of your TFC workspace, your TFC token, your GitHub user ID, your GitHub personal access token, your GitHub user name (first and last names), your GitHub email, and an OAuth ID for a VCS connection in your TFC organization.
 3. Providing all of those will enable later solve scripts in the current TFC track to properly skip ahead to later challenges.
 
 To actually skip one or more challenges while running one of the TFC tracks, return to the track's home page and click the "Skip to" button of the challenge you wish to skip to.

--- a/instruqt-tracks/terraform-cloud-aws/a-sentinel-stands-guard/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/a-sentinel-stands-guard/solve-workstation
@@ -98,7 +98,7 @@ EOF
 # Do git operations to add tags (but not for workshops-testbot)
 if [[ -f /root/skipconfig.json ]]; then
   GITUSERID=$(jq -r .gituserid < /root/skipconfig.json)
-  GITPWD=$(jq -r .gitpwd < /root/skipconfig.json)
+  GITPAT=$(jq -r .gitpat < /root/skipconfig.json)
   git pull
   # Add Department tag
   sed -i "s/Name = \"\${var.prefix}-hashicat-instance\"/Name = \"\${var.prefix}-hashicat-instance\"\n    Department = \"devops\"/" main.tf
@@ -107,7 +107,7 @@ if [[ -f /root/skipconfig.json ]]; then
   cat <<-EOF > /root/.netrc
   machine github.com
   login $GITUSERID
-  password $GITPWD
+  password $GITPAT
 EOF
   git push origin master
   # Add Billable tag

--- a/instruqt-tracks/terraform-cloud-aws/private-module-registry/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/private-module-registry/solve-workstation
@@ -21,7 +21,7 @@ EOF
 if [[ -f /root/skipconfig.json ]]; then
   ORG=$(jq -r .org < /root/skipconfig.json)
   GITUSERID=$(jq -r .gituserid < /root/skipconfig.json)
-  GITPWD=$(jq -r .gitpwd < /root/skipconfig.json)
+  GITPAT=$(jq -r .gitpat < /root/skipconfig.json)
   # Set ORG in s3-bucket.tf
   sed -i "s/instruqt-circleci/$ORG/g" s3-bucket.tf
   git add .
@@ -29,7 +29,7 @@ if [[ -f /root/skipconfig.json ]]; then
   cat <<-EOF > /root/.netrc
   machine github.com
   login $GITUSERID
-  password $GITPWD
+  password $GITPAT
 EOF
   git push origin master
 fi

--- a/instruqt-tracks/terraform-cloud-aws/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/setup-our-environment/setup-workstation
@@ -65,8 +65,8 @@ echo
 echo "Please enter your GitHub user ID."
 read GITUSERID
 echo
-echo "Please enter your GitHub password or personal access token."
-read GITPWD
+echo "Please enter your GitHub personal access token."
+read GITPAT
 echo
 echo "Please enter your GitHub user name (<first_name> <last_name>)."
 read GITUSERNAME
@@ -75,7 +75,7 @@ echo "Please enter your GitHub email."
 read GITEMAIL
 echo
 echo "Please enter your oauth-id. You can find it at this URL:"
-echo "https://app.terraform.io/app/${ORG}/settings/version-control"
+echo "https://app.terraform.io/app/\${ORG}/settings/version-control"
 echo "If you haven't set up VCS integration yet, simply hit enter."
 read OAUTHID
 echo
@@ -83,7 +83,7 @@ echo "Organization: \$ORG"
 echo "Workspace   : \$WORKSPACE"
 echo "Token       : \$TOKEN"
 echo "GitHub User ID : \$GITUSERID"
-echo "GitHub Password : \$GITPWD"
+echo "GitHub Personal Access Token : \$GITPAT"
 echo "GitHub User Name : \$GITUSERNAME"
 echo "GitHub Email : \$GITEMAIL"
 echo "OAuth ID    : \$OAUTHID"
@@ -103,7 +103,7 @@ cat <<-EOM > /root/skipconfig.json
   "workspace": "\$WORKSPACE",
   "token": "\$TOKEN",
   "gituserid": "\$GITUSERID",
-  "gitpwd": "\$GITPWD",
+  "gitpat": "\$GITPAT",
   "gitusername": "\$GITUSERNAME",
   "gitemail": "\$GITEMAIL",
   "oauthid": "\$OAUTHID"

--- a/instruqt-tracks/terraform-cloud-aws/track.yml
+++ b/instruqt-tracks/terraform-cloud-aws/track.yml
@@ -437,7 +437,7 @@ challenges:
 
     At this time, the last command **must** be run on the "Shell" tab since authenticating to GitHub from the VS Code Editor's terminal does not work.
 
-    Note that you'll have to provide your GitHub username and password or personal access token in order to complete the `git push` command.
+    Note that you'll have to provide your GitHub username and personal access token in order to complete the `git push` command.
 
     If you have two-factor authentication enabled and don't remember your personal access token,  you'll need to create a new one. To do that, log onto GitHub and visit the Tokens page:
 
@@ -653,7 +653,7 @@ challenges:
 
     After the module is completely published, please select version `2.2.0` of the module by clicking `Change` under **Version** in the upper left section of your screen. If `2.2.0` is not visible, refresh the page once as versions may take a moment to publish.
 
-    Create a new Terraform file called `s3-bucket.tf` in the hashicat-aws directory and use the module in this file to create a new S3 bucket for Gaurav. You can copy the module creation code from the "Provision Instructions" section of the module's page in your Private Module Registry.
+    Create a new Terraform file called `s3-bucket.tf` in the hashicat-aws directory and use the module in this file to create a new S3 bucket for Gaurav. You can copy the module creation code from the "Usage Instructions" section of the module's page in your Private Module Registry.
 
     Click on the "Inputs" tab of the module. This indicates that you have to specify several module variables (inputs), but they are all marked as optional. We recommend that you set the `bucket_prefix` module variable (input) to the value of your `prefix` variable. The AWS provider will then generate a bucket name that starts with your prefix.
 
@@ -766,7 +766,7 @@ challenges:
   - type: text
     contents: "\U0001F431‍\U0001F4BB Congratulations! You've been promoted to Terraform Cloud Ninja."
   assignment: |
-    The Terraform private module registry automatically syncs modules from the public registry.
+    The Terraform private module registry automatically updates private modules copied from the public registry if the original public modules are updated.
   answers:
   - "True"
   - "False"
@@ -801,4 +801,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1800
-checksum: "2890960223448803216"
+checksum: "8208392442982860827"

--- a/instruqt-tracks/terraform-cloud-aws/versioned-infrastructure/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/versioned-infrastructure/solve-workstation
@@ -12,7 +12,7 @@ WORKSPACE_ID=$(curl -s --header "Authorization: Bearer $TOKEN"   --header "Conte
 
 if [[ -f /root/skipconfig.json ]]; then
   GITUSERID=$(jq -r .gituserid < /root/skipconfig.json)
-  GITPWD=$(jq -r .gitpwd < /root/skipconfig.json)
+  GITPAT=$(jq -r .gitpat < /root/skipconfig.json)
   GITUSERNAME=$(jq -r .gitusername < /root/skipconfig.json)
   GITEMAIL=$(jq -r .gitemail < /root/skipconfig.json)
   OAUTHID=$(jq -r .oauthid < /root/skipconfig.json)
@@ -35,7 +35,7 @@ if [[ "$GITUSERID" != "workshops-testbot" ]]; then
   cat <<-EOF > /root/.netrc
   machine github.com
   login $GITUSERID
-  password $GITPWD
+  password $GITPAT
 EOF
   git push origin master
 fi

--- a/instruqt-tracks/terraform-cloud-azure/a-sentinel-stands-guard/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/a-sentinel-stands-guard/solve-workstation
@@ -98,7 +98,7 @@ EOF
 # Do git operations to add tags (but not for workshops-testbot)
 if [[ -f /root/skipconfig.json ]]; then
   GITUSERID=$(jq -r .gituserid < /root/skipconfig.json)
-  GITPWD=$(jq -r .gitpwd < /root/skipconfig.json)
+  GITPAT=$(jq -r .gitpat < /root/skipconfig.json)
   git pull
   # Add Department tag
   sed -i "s/tags = {}/tags = {\n    Department = \"devops\"\n  }/" main.tf
@@ -107,7 +107,7 @@ if [[ -f /root/skipconfig.json ]]; then
   cat <<-EOF > /root/.netrc
   machine github.com
   login $GITUSERID
-  password $GITPWD
+  password $GITPAT
 EOF
   git push origin master
   # Add Billable tag

--- a/instruqt-tracks/terraform-cloud-azure/private-module-registry/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/private-module-registry/solve-workstation
@@ -23,7 +23,7 @@ EOF
 if [[ -f /root/skipconfig.json ]]; then
   ORG=$(jq -r .org < /root/skipconfig.json)
   GITUSERID=$(jq -r .gituserid < /root/skipconfig.json)
-  GITPWD=$(jq -r .gitpwd < /root/skipconfig.json)
+  GITPAT=$(jq -r .gitpat < /root/skipconfig.json)
   # Set ORG in vnetc.tf
   sed -i "s/instruqt-circleci/$ORG/g" vnet.tf
   git add .
@@ -31,7 +31,7 @@ if [[ -f /root/skipconfig.json ]]; then
   cat <<-EOF > /root/.netrc
   machine github.com
   login $GITUSERID
-  password $GITPWD
+  password $GITPAT
 EOF
   git push origin master
 fi

--- a/instruqt-tracks/terraform-cloud-azure/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/setup-our-environment/setup-workstation
@@ -68,8 +68,8 @@ echo
 echo "Please enter your GitHub user ID."
 read GITUSERID
 echo
-echo "Please enter your GitHub password or personal access token."
-read GITPWD
+echo "Please enter your GitHub personal access token."
+read GITPAT
 echo
 echo "Please enter your GitHub user name (<first_name> <last_name>)."
 read GITUSERNAME
@@ -78,7 +78,7 @@ echo "Please enter your GitHub email."
 read GITEMAIL
 echo
 echo "Please enter your oauth-id. You can find it at this URL:"
-echo "https://app.terraform.io/app/${ORG}/settings/version-control"
+echo "https://app.terraform.io/app/\${ORG}/settings/version-control"
 echo "If you haven't set up VCS integration yet, simply hit enter."
 read OAUTHID
 echo
@@ -86,7 +86,7 @@ echo "Organization: \$ORG"
 echo "Workspace   : \$WORKSPACE"
 echo "Token       : \$TOKEN"
 echo "GitHub User ID : \$GITUSERID"
-echo "GitHub Password : \$GITPWD"
+echo "GitHub Personal Access Token : \$GITPAT"
 echo "GitHub User Name : \$GITUSERNAME"
 echo "GitHub Email : \$GITEMAIL"
 echo "OAuth ID    : \$OAUTHID"
@@ -106,7 +106,7 @@ cat <<-EOM > /root/skipconfig.json
   "workspace": "\$WORKSPACE",
   "token": "\$TOKEN",
   "gituserid": "\$GITUSERID",
-  "gitpwd": "\$GITPWD",
+  "gitpat": "\$GITPAT",
   "gitusername": "\$GITUSERNAME",
   "gitemail": "\$GITEMAIL",
   "oauthid": "\$OAUTHID"

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -443,7 +443,7 @@ challenges:
 
     At this time, the last command **must** be run on the "Shell" tab since authenticating to GitHub from the VS Code Editor's terminal does not work.
 
-    Note that you'll have to provide your GitHub username and password or personal access token in order to complete the `git push` command.
+    Note that you'll have to provide your GitHub username and personal access token in order to complete the `git push` command.
 
     If you have two-factor authentication enabled and don't remember your personal access token,  you'll need to create a new one. To do that, log onto GitHub and visit the Tokens page:
 
@@ -661,7 +661,7 @@ challenges:
 
     Click on the "Inputs" tab of the module. This indicates that you have to specify the `resource_group_name` module variable when creating an instance of the module. For inputs that reference resources already created in your main.tf file, we recommend that you use references that refer to the appropriate attributes of those resources. But you can also use hard-coded values if you prefer.
 
-    Create a new Terraform file called `vnet.tf` in the hashicat-azure directory and use the module in this file to create a new Virtual Network for Gaurav. You can copy the module creation code from the "Provision Instructions" section of the module's page in your Private Module Registry and just add the required `resource_group_name` module variable.
+    Create a new Terraform file called `vnet.tf` in the hashicat-azure directory and use the module in this file to create a new Virtual Network for Gaurav. You can copy the module creation code from the "Usage Instructions" section of the module's page in your Private Module Registry and just add the required `resource_group_name` module variable.
 
     Since you are editing a new file, you need to save it even if you are using the VS Code Editor. Use the File > Save menu and type "vnet.tf" for the name. If you are using the Instruqt Text Editor, just click the disk icon above the file.
 
@@ -772,7 +772,7 @@ challenges:
   - type: text
     contents: "\U0001F431‍\U0001F4BB Congratulations! You've been promoted to Terraform Cloud Ninja."
   assignment: |
-    The Terraform private module registry automatically syncs modules from the public registry.
+    The Terraform private module registry automatically updates private modules copied from the public registry if the original public modules are updated.
   answers:
   - "True"
   - "False"
@@ -807,4 +807,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1800
-checksum: "4122879090301812200"
+checksum: "10479087244889973588"

--- a/instruqt-tracks/terraform-cloud-azure/versioned-infrastructure/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/versioned-infrastructure/solve-workstation
@@ -12,7 +12,7 @@ WORKSPACE_ID=$(curl -s --header "Authorization: Bearer $TOKEN"   --header "Conte
 
 if [[ -f /root/skipconfig.json ]]; then
   GITUSERID=$(jq -r .gituserid < /root/skipconfig.json)
-  GITPWD=$(jq -r .gitpwd < /root/skipconfig.json)
+  GITPAT=$(jq -r .gitpat < /root/skipconfig.json)
   GITUSERNAME=$(jq -r .gitusername < /root/skipconfig.json)
   GITEMAIL=$(jq -r .gitemail < /root/skipconfig.json)
   OAUTHID=$(jq -r .oauthid < /root/skipconfig.json)
@@ -35,7 +35,7 @@ if [[ "$GITUSERID" != "workshops-testbot" ]]; then
   cat <<-EOF > /root/.netrc
   machine github.com
   login $GITUSERID
-  password $GITPWD
+  password $GITPAT
 EOF
   git push origin master
 fi

--- a/instruqt-tracks/terraform-cloud-gcp/a-sentinel-stands-guard/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-gcp/a-sentinel-stands-guard/solve-workstation
@@ -98,7 +98,7 @@ EOF
 ## Do git operations to add labels (but not for workshops-testbot)
 if [[ -f /root/skipconfig.json ]]; then
   GITUSERID=$(jq -r .gituserid < /root/skipconfig.json)
-  GITPWD=$(jq -r .gitpwd < /root/skipconfig.json)
+  GITPAT=$(jq -r .gitpat < /root/skipconfig.json)
   git pull
   # Add Department label
   sed -i "s/name = \"hashicat\"/name = \"hashicat\"\n    department = \"devops\"/" main.tf
@@ -107,7 +107,7 @@ if [[ -f /root/skipconfig.json ]]; then
   cat <<-EOF > /root/.netrc
   machine github.com
   login $GITUSERID
-  password $GITPWD
+  password $GITPAT
 EOF
   git push origin master
   # Add Billable label

--- a/instruqt-tracks/terraform-cloud-gcp/private-module-registry/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-gcp/private-module-registry/solve-workstation
@@ -29,7 +29,7 @@ EOF
 if [[ -f /root/skipconfig.json ]]; then
   ORG=$(jq -r .org < /root/skipconfig.json)
   GITUSERID=$(jq -r .gituserid < /root/skipconfig.json)
-  GITPWD=$(jq -r .gitpwd < /root/skipconfig.json)
+  GITPAT=$(jq -r .gitpat < /root/skipconfig.json)
   # Set ORG in vpc.tf
   sed -i "s/instruqt-circleci/$ORG/g" vpc.tf
   git add .
@@ -37,7 +37,7 @@ if [[ -f /root/skipconfig.json ]]; then
   cat <<-EOF > /root/.netrc
   machine github.com
   login $GITUSERID
-  password $GITPWD
+  password $GITPAT
 EOF
   git push origin master
 fi

--- a/instruqt-tracks/terraform-cloud-gcp/setup-our-environment/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-gcp/setup-our-environment/setup-workstation
@@ -73,8 +73,8 @@ echo
 echo "Please enter your GitHub user ID."
 read GITUSERID
 echo
-echo "Please enter your GitHub password or personal access token."
-read GITPWD
+echo "Please enter your GitHub personal access token."
+read GITPAT
 echo
 echo "Please enter your GitHub user name (<first_name> <last_name>)."
 read GITUSERNAME
@@ -83,7 +83,7 @@ echo "Please enter your GitHub email."
 read GITEMAIL
 echo
 echo "Please enter your oauth-id. You can find it at this URL:"
-echo "https://app.terraform.io/app/${ORG}/settings/version-control"
+echo "https://app.terraform.io/app/\${ORG}/settings/version-control"
 echo "If you haven't set up VCS integration yet, simply hit enter."
 read OAUTHID
 echo
@@ -91,7 +91,7 @@ echo "Organization: \$ORG"
 echo "Workspace   : \$WORKSPACE"
 echo "Token       : \$TOKEN"
 echo "GitHub User ID : \$GITUSERID"
-echo "GitHub Password : \$GITPWD"
+echo "GitHub Personal Access Token : \$GITPAT"
 echo "GitHub User Name : \$GITUSERNAME"
 echo "GitHub Email : \$GITEMAIL"
 echo "OAuth ID    : \$OAUTHID"
@@ -111,7 +111,7 @@ cat <<-EOM > /root/skipconfig.json
   "workspace": "\$WORKSPACE",
   "token": "\$TOKEN",
   "gituserid": "\$GITUSERID",
-  "gitpwd": "\$GITPWD",
+  "gitpat": "\$GITPAT",
   "gitusername": "\$GITUSERNAME",
   "gitemail": "\$GITEMAIL",
   "oauthid": "\$OAUTHID"

--- a/instruqt-tracks/terraform-cloud-gcp/track.yml
+++ b/instruqt-tracks/terraform-cloud-gcp/track.yml
@@ -443,7 +443,7 @@ challenges:
 
     At this time, the last command **must** be run on the "Shell" tab since authenticating to GitHub from the VS Code Editor's terminal does not work.
 
-    Note that you'll have to provide your GitHub username and password or personal access token in order to complete the `git push` command.
+    Note that you'll have to provide your GitHub username and personal access token in order to complete the `git push` command.
 
     If you have two-factor authentication enabled and don't remember your personal access token,  you'll need to create a new one. To do that, log onto GitHub and visit the Tokens page:
 
@@ -661,7 +661,7 @@ challenges:
 
     Click on the "Inputs" tab of the module. This indicates that you have to specify the `network_name`, `project_id`, and `subnets` module variables (inputs) for this module.
 
-    Create a new Terraform file called `vpc.tf` in the hashicat-gcp directory and use the module in this file to create a new VPC for Gaurav. You can copy the module creation code from the "Provision Instructions" section of the module's page in your Private Module Registry and then add the required inputs as follows:
+    Create a new Terraform file called `vpc.tf` in the hashicat-gcp directory and use the module in this file to create a new VPC for Gaurav. You can copy the module creation code from the "Usage Instructions" section of the module's page in your Private Module Registry and then add the required inputs as follows:
       * Set `network_name` to any name you want such as `gaurav-network`.
       * Set `project_id` to `var.project` (and make sure that the VS Code Editor does not change this to `var.project_id`).
       * Set `subnets` like this:
@@ -784,7 +784,7 @@ challenges:
   - type: text
     contents: "\U0001F431‍\U0001F4BB Congratulations! You've been promoted to Terraform Cloud Ninja."
   assignment: |
-    The Terraform private module registry automatically syncs modules from the public registry.
+    The Terraform private module registry automatically updates private modules copied from the public registry if the original public modules are updated.
   answers:
   - "True"
   - "False"
@@ -819,4 +819,4 @@ challenges:
     hostname: workstation
   difficulty: basic
   timelimit: 1800
-checksum: "4172565085542851174"
+checksum: "6476741821012600174"

--- a/instruqt-tracks/terraform-cloud-gcp/versioned-infrastructure/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-gcp/versioned-infrastructure/solve-workstation
@@ -12,7 +12,7 @@ WORKSPACE_ID=$(curl -s --header "Authorization: Bearer $TOKEN"   --header "Conte
 
 if [[ -f /root/skipconfig.json ]]; then
   GITUSERID=$(jq -r .gituserid < /root/skipconfig.json)
-  GITPWD=$(jq -r .gitpwd < /root/skipconfig.json)
+  GITPAT=$(jq -r .gitpat < /root/skipconfig.json)
   GITUSERNAME=$(jq -r .gitusername < /root/skipconfig.json)
   GITEMAIL=$(jq -r .gitemail < /root/skipconfig.json)
   OAUTHID=$(jq -r .oauthid < /root/skipconfig.json)
@@ -35,7 +35,7 @@ if [[ "$GITUSERID" != "workshops-testbot" ]]; then
   cat <<-EOF > /root/.netrc
   machine github.com
   login $GITUSERID
-  password $GITPWD
+  password $GITPAT
 EOF
   git push origin master
 fi


### PR DESCRIPTION
This PR addresses https://github.com/hashicorp/field-workshops-terraform/issues/275.  But beyond changing the instructions in assignments to indicate that GitHub personal access tokens must be used (instead of saying that GitHub passwords and personal access tokens can be used), it also updates the fastforward script to use a GITPAT variable instead of the previous GITPWD variable.

There is also a fix to the fourth quiz in all workshops to adjust for the new publicly curated modules in the PMR.

There are also some other minor changes such as updating "Provision Instructions" to "Usage Instructions" when describing where to get the Terraform code for using modules from the private module registry.