### PR TITLE
Removed reference to Chef provisioner (Intro to TF on AWS)

### DIFF
--- a/docs/slides/aws/terraform-oss/index.md
+++ b/docs/slides/aws/terraform-oss/index.md
@@ -999,9 +999,6 @@ class: compact
 
 Terraform works well with common config management tools like Chef, Puppet or Ansible.
 
-Official Chef Terraform provisioner:<br>
-https://www.terraform.io/docs/provisioners/chef.html
-
 Run Puppet with 'local-exec':<br>
 https://www.terraform.io/docs/provisioners/local-exec.html
 


### PR DESCRIPTION
Chef provisioner was removed in v0.15.  If you would like to add details about integrations with Chef, you could. I just removed the reference for now. 