### PR TITLE
Update expression used to filter for correct team id.

### DIFF
--- a/instruqt-tracks/terraform-cloud-aws/sharing-is-caring/check-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/sharing-is-caring/check-workstation
@@ -15,9 +15,9 @@ TOKEN=$(grep token /root/.terraform.d/credentials.tfrc.json | cut -d '"' -f4)
 # Get our team IDs. In the test environment these teams are pre-created.
 ADMINS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("[Aa]dmin*")) | .id')
 
-DEVS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("developers")) | .id')
+DEVS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("^developers$")) | .id')
 
-MANAGERS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("managers")) | .id')
+MANAGERS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("^managers$")) | .id')
 
 # Fetch our workspace ID
 WORKSPACE_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-aws | jq -r .data.id)

--- a/instruqt-tracks/terraform-cloud-azure/sharing-is-caring/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/sharing-is-caring/check-workstation
@@ -15,9 +15,9 @@ TOKEN=$(grep token /root/.terraform.d/credentials.tfrc.json | cut -d '"' -f4)
 # Get our team IDs. In the test environment these teams are pre-created.
 ADMINS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("[Aa]dmin*")) | .id')
 
-DEVS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("developers")) | .id')
+DEVS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("^developers$")) | .id')
 
-MANAGERS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("managers")) | .id')
+MANAGERS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("^managers$")) | .id')
 
 # Fetch our workspace ID
 WORKSPACE_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-azure | jq -r .data.id)

--- a/instruqt-tracks/terraform-cloud-gcp/sharing-is-caring/check-workstation
+++ b/instruqt-tracks/terraform-cloud-gcp/sharing-is-caring/check-workstation
@@ -15,9 +15,9 @@ TOKEN=$(grep token /root/.terraform.d/credentials.tfrc.json | cut -d '"' -f4)
 # Get our team IDs. In the test environment these teams are pre-created.
 ADMINS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("[Aa]dmin*")) | .id')
 
-DEVS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("developers")) | .id')
+DEVS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("^developers$")) | .id')
 
-MANAGERS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("managers")) | .id')
+MANAGERS_TEAM_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/teams | jq -r '.data | .[] | select(.attributes.name|test("^managers$")) | .id')
 
 # Fetch our workspace ID
 WORKSPACE_ID=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-gcp | jq -r .data.id)


### PR DESCRIPTION
The jq test function matches a regex and the current regex will match any string that has `developers` in it. 

A participant created multiples teams with the string `developers`(developers and developers-web) in the name so `DEVS_TEAM_ID` got a list of 2 values as the result of the expression. 

This caused the [actual check](https://github.com/hashicorp/field-workshops-terraform/blob/65a831b25749937cea158388371bf0a8d03ba59b/instruqt-tracks/terraform-cloud-aws/sharing-is-caring/check-workstation#L36-L38) to fail, with the error message "developers group has not been attached". This wasn't the case for the participant and they were confused.