### PR TITLE
update TF 1.1.4, fix links

### DIFF
--- a/docs/slides/aws/terraform-cloud/index.md
+++ b/docs/slides/aws/terraform-cloud/index.md
@@ -1015,7 +1015,7 @@ Why Consider Terraform Enterprise Over Open Source?
 https://www.hashicorp.com/resources/why-consider-terraform-enterprise-over-open-source
 
 Terraform AWS Provider Documentation
-https://www.terraform.io/docs/providers/aws/
+https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
 ---
 name: Feedback-Survey

--- a/docs/slides/aws/terraform-oss/index.md
+++ b/docs/slides/aws/terraform-oss/index.md
@@ -1200,7 +1200,7 @@ Terraform - Beyond the Basics with AWS<br>
 https://aws.amazon.com/blogs/apn/terraform-beyond-the-basics-with-aws/
 
 Terraform AWS Provider Documentation<br>
-https://www.terraform.io/docs/providers/aws/index.html
+https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
 Link to this Slide Deck<br>
 https://git.io/JerH6

--- a/docs/slides/azure/terraform-cloud/index.md
+++ b/docs/slides/azure/terraform-cloud/index.md
@@ -1011,7 +1011,7 @@ Why Consider Terraform Enterprise Over Open Source?
 https://www.hashicorp.com/resources/why-consider-terraform-enterprise-over-open-source
 
 Terraform Azure Provider Documentation
-https://www.terraform.io/docs/providers/azure/
+https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs
 
 ---
 name: Feedback-Survey

--- a/docs/slides/azure/terraform-oss/index.md
+++ b/docs/slides/azure/terraform-oss/index.md
@@ -1185,7 +1185,7 @@ Terraform with Azure Cloudshell<br>
 https://docs.microsoft.com/en-us/azure/terraform/terraform-cloud-shell
 
 Terraform Azurerm Provider Documentation<br>
-https://www.terraform.io/docs/providers/azurerm/
+https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/
 
 Link to this Slide Deck<br>
 https://git.io/JeuCI

--- a/docs/slides/gcp/terraform-cloud/index.md
+++ b/docs/slides/gcp/terraform-cloud/index.md
@@ -1009,7 +1009,7 @@ Why Consider Terraform Enterprise Over Open Source?
 https://www.hashicorp.com/resources/why-consider-terraform-enterprise-over-open-source
 
 Terraform GCP Provider Documentation
-https://www.terraform.io/docs/providers/google
+https://registry.terraform.io/providers/google
 
 ---
 name: Feedback-Survey

--- a/docs/slides/gcp/terraform-oss/index.md
+++ b/docs/slides/gcp/terraform-oss/index.md
@@ -1166,7 +1166,7 @@ Managing Google Cloud Projects with Terraform<br>
 https://cloud.google.com/community/tutorials/managing-gcp-projects-with-terraform
 
 Terraform Google Provider Documentation<br>
-https://www.terraform.io/docs/providers/google/index.html
+https://registry.terraform.io/providers/hashicorp/google/latest/docs
 
 Link to this Slide Deck<br>
 https://git.io/JvdX7

--- a/docs/slides/korean/aws/terraform-cloud/index.md
+++ b/docs/slides/korean/aws/terraform-cloud/index.md
@@ -1010,7 +1010,7 @@ Why Consider Terraform Enterprise Over Open Source?
 https://www.hashicorp.com/resources/why-consider-terraform-enterprise-over-open-source
 
 Terraform AWS Provider Documentation
-https://www.terraform.io/docs/providers/aws/
+https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
 ---
 name: Feedback-Survey

--- a/docs/slides/korean/aws/terraform-oss/index.md
+++ b/docs/slides/korean/aws/terraform-oss/index.md
@@ -1201,7 +1201,7 @@ Terraform - Beyond the Basics with AWS<br>
 https://aws.amazon.com/blogs/apn/terraform-beyond-the-basics-with-aws/
 
 Terraform AWS Provider Documentation<br>
-https://www.terraform.io/docs/providers/aws/index.html
+https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
 Link to this Slide Deck<br>
 https://git.io/JerH6

--- a/instruqt-tracks/sentinel-for-terraform-v4/track.yml
+++ b/instruqt-tracks/sentinel-for-terraform-v4/track.yml
@@ -67,8 +67,8 @@ challenges:
       Your task is to complete and test a Sentinel policy that restricts the Vault authentication methods (backends) provisioned by Terraform's Vault Provider.
 
       Don't worry if you don't know much about Vault. You'll find what you need in these URLs:
-      https://www.terraform.io/docs/providers/vault/r/auth_backend.html
-      https://www.vaultproject.io/docs/auth/index.html
+      https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/auth_backend
+      https://www.vaultproject.io/docs/auth
 
       If you look at the links for various Vault auth methods under the second of these links, you'll see that the `vault auth enable` command always specifies the auth method type with a single lower-case string identical to or similar to the full name of the auth method. These strings are also what the Terraform Vault Provider uses when creating Vault auth methods.
   assignment: |-
@@ -102,7 +102,7 @@ challenges:
 
     Next, you need to replace `<resource_type>` in the call to the "find_resources" method. We've already told you the resource type above.
 
-    Next, replace `<attribute>` and `<list>` in the call to the "filter_attribute_not_in_list" function. You can figure out the attribute you want to restrict by reading the [auth_backend](https://www.terraform.io/docs/providers/vault/r/auth_backend.html) documentation. The name of the list to use should be obvious.
+    Next, replace `<attribute>` and `<list>` in the call to the "filter_attribute_not_in_list" function. You can figure out the attribute you want to restrict by reading the [auth_backend](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/auth_backend) documentation. The name of the list to use should be obvious.
 
     After making all the substitutions, save the "restrict-vault-auth-methods.sentinel" policy by clicking the disk icon above the file.
 
@@ -153,7 +153,7 @@ challenges:
       Your task is to complete and test a Sentinel policy that requires that all AWS IAM access keys provisioned by Terraform's AWS Provider include a PGP key.
   - type: text
     contents: |-
-      Don't worry if you don't know much about AWS. You can find the information you need in this URL: https://www.terraform.io/docs/providers/aws/index.html
+      Don't worry if you don't know much about AWS. You can find the information you need in this URL: https://registry.terraform.io/providers/hashicorp/aws/latest/docs
 
       You can use the filter link at the top of the left-hand menu on that page to search for resources that have "access". There is only one good match that also has "key". Click on it to see what attributes are available for it.
 
@@ -296,7 +296,7 @@ challenges:
     contents: |-
       Your task is to complete and test a Sentinel policy that requires that all AWS Certificate Manager (ACM) Certificates referenced by a data source in Terraform's AWS Provider have domains that are subdomains of "hashidemos.io". (This means the domains must end in ".hashidemos.io".)
 
-      As in Exercise 2, you can look at the [AWS Provider](https://www.terraform.io/docs/providers/aws/index.html) documentation to search for the relevant data source.
+      As in Exercise 2, you can look at the [AWS Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs) documentation to search for the relevant data source.
 
       You can use the filter link at the top of the left-hand menu on that page to search for a data source that has "acm". Click on it to see what attributes are available for it.
 
@@ -439,7 +439,7 @@ challenges:
     contents: |-
       Your task is to complete and test a Sentinel policy that requires Google Cloud Platform (GCP) compute instances provisioned by Terraform's Google Provider to use the public image "debian-cloud/debian-9".
 
-      Don't worry if you don't know much about GCP. You can look at the [Google Provider](https://www.terraform.io/docs/providers/google/index.html) documentation to find the relevant GCP resource. (Be sure to pick a resource and not a data source with the same name.)
+      Don't worry if you don't know much about GCP. You can look at the [Google Provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs) documentation to find the relevant GCP resource. (Be sure to pick a resource and not a data source with the same name.)
 
       You might also find the documentation for Sentinel [lists](https://docs.hashicorp.com/sentinel/language/lists), [maps](https://docs.hashicorp.com/sentinel/language/maps), and the standard [types](https://docs.hashicorp.com/sentinel/imports/types) import useful.
   assignment: |-
@@ -778,4 +778,4 @@ challenges:
     hostname: sentinel
   difficulty: basic
   timelimit: 1800
-checksum: "4834061913147924417"
+checksum: "8029981488670112052"

--- a/instruqt-tracks/terraform-cloud-aws/config.yml
+++ b/instruqt-tracks/terraform-cloud-aws/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: workstation
-  image: instruqt-hashicorp/tfc-workstation-1-0-7
+  image: instruqt-hashicorp/tfc-workstation-1-1-4
   shell: /bin/bash -l
   machine_type: n1-standard-1
 aws_accounts:

--- a/instruqt-tracks/terraform-cloud-aws/private-module-registry/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/private-module-registry/solve-workstation
@@ -13,7 +13,7 @@ if [[ -f /root/skipconfig.json ]]; then
   cat <<-EOF > s3-bucket.tf
 module "s3-bucket" {
   source  = "app.terraform.io/$ORG/s3-bucket/aws"
-  version = "2.2.0"
+  version = "2.8.0"
   bucket_prefix = var.prefix
 }
 EOF

--- a/instruqt-tracks/terraform-cloud-aws/track.yml
+++ b/instruqt-tracks/terraform-cloud-aws/track.yml
@@ -707,11 +707,11 @@ challenges:
 
     Note the "Source Code" link that points at the GitHub repository for this module. Click on the Source URL. As you did in previous challenges, create your own fork of this repository with the "Fork" button.
 
-    Back in the Terraform Cloud UI, click on the "Registry" tab at the top of the page. "Publish" button followed by "Module". Click on the "GitHub" button and select the terraform-aws-s3-bucket repository that you just forked.
+    Back in the Terraform Cloud UI, click on the "Registry" tab at the top of the page. Then click the "Publish" button and the "Module" button that appears beneath it. Click on the "GitHub" button and select the terraform-aws-s3-bucket repository that you just forked.
 
     Click on the "Publish module" button.
 
-    After the module is completely published, please select version `2.2.0` of the module by clicking `Change` under **Version** in the upper left section of your screen. If `2.2.0` is not visible, refresh the page once as versions may take a moment to publish.
+    After the module is completely published, please select version `2.8.0` of the module by clicking `Change` under **Version** in the upper left section of your screen. If `2.8.0` is not visible, refresh the page once as versions may take a moment to publish.
 
     Create a new Terraform file called `s3-bucket.tf` in the hashicat-aws directory and use the module in this file to create a new S3 bucket for Gaurav. You can copy the module creation code from the "Usage Instructions" section of the module's page in your Private Module Registry.
 
@@ -849,4 +849,4 @@ challenges:
     path: /root/hashicat-aws
   difficulty: basic
   timelimit: 1800
-checksum: "3412229663246245313"
+checksum: "3401603143817690904"

--- a/instruqt-tracks/terraform-cloud-aws/track_scripts/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/track_scripts/setup-workstation
@@ -12,7 +12,7 @@ do
 done
 
 # Set Terraform Version
-TERRAFORM_VERSION="1.0.7"
+TERRAFORM_VERSION="1.1.4"
 
 # Install desired version of Terraform
 rm -f /usr/local/bin/terraform

--- a/instruqt-tracks/terraform-cloud-azure/config.yml
+++ b/instruqt-tracks/terraform-cloud-azure/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: workstation
-  image: instruqt-hashicorp/tfc-workstation-1-0-7
+  image: instruqt-hashicorp/tfc-workstation-1-1-4
   shell: /bin/bash -l
   machine_type: n1-standard-1
 azure_subscriptions:

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -712,7 +712,7 @@ challenges:
 
     Note the "Source Code" link that points at the GitHub repository for this module. Click on the Source URL. As you did in previous challenges, create your own fork of this repository with the "Fork" button. Make sure you fork the `terraform-azurerm-network` module and NOT the `terraform-azurerm-vnet` module also linked on the page.
 
-    Back in the Terraform Cloud UI, click on the "Registry" tab at the top of the page. Click on the "Publish" button followed by "Module". Click on the "GitHub" button and select the terraform-azurerm-network repository that you just forked.
+    Back in the Terraform Cloud UI, click on the "Registry" tab at the top of the page. Then click the "Publish" button and the "Module" button that appears beneath it. Click on the "GitHub" button and select the terraform-azurerm-network repository that you just forked.
 
     Click on the "Publish module" button.
 
@@ -854,4 +854,4 @@ challenges:
     path: /root/hashicat-azure
   difficulty: basic
   timelimit: 1800
-checksum: "14715075915022802939"
+checksum: "8368245064164518422"

--- a/instruqt-tracks/terraform-cloud-azure/track_scripts/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/track_scripts/setup-workstation
@@ -12,7 +12,7 @@ do
 done
 
 # Set Terraform Version
-TERRAFORM_VERSION="1.0.7"
+TERRAFORM_VERSION="1.1.4"
 
 # Install desired version of Terraform
 rm -f /usr/local/bin/terraform

--- a/instruqt-tracks/terraform-cloud-gcp/config.yml
+++ b/instruqt-tracks/terraform-cloud-gcp/config.yml
@@ -1,7 +1,7 @@
 version: "2"
 virtualmachines:
 - name: workstation
-  image: instruqt-hashicorp/tfc-workstation-1-0-7
+  image: instruqt-hashicorp/tfc-workstation-1-1-4
   shell: /bin/bash -l
   machine_type: n1-standard-1
 gcp_projects:

--- a/instruqt-tracks/terraform-cloud-gcp/track.yml
+++ b/instruqt-tracks/terraform-cloud-gcp/track.yml
@@ -710,7 +710,7 @@ challenges:
 
     Note the "Source Code" link that points at the GitHub repository for this module. Click on the Source URL. As you did in previous challenges, create your own fork of this repository with the "Fork" button.
 
-    Back in the Terraform Cloud UI, click on the "Registry" tab at the top of the page. Click on the "Publish" button followed by "Module". Click on the "GitHub" button and select the terraform-google-network repository that you just forked.
+    Back in the Terraform Cloud UI, click on the "Registry" tab at the top of the page. Then click the "Publish" button and the "Module" button that appears beneath it. Click on the "GitHub" button and select the terraform-google-network repository that you just forked.
 
     Click on the "Publish module" button.
 
@@ -864,4 +864,4 @@ challenges:
     path: /root/hashicat-gcp
   difficulty: basic
   timelimit: 1800
-checksum: "15053254345161563091"
+checksum: "18431315758612781693"

--- a/instruqt-tracks/terraform-cloud-gcp/track_scripts/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-gcp/track_scripts/setup-workstation
@@ -12,7 +12,7 @@ do
 done
 
 # Set Terraform Version
-TERRAFORM_VERSION="1.0.7"
+TERRAFORM_VERSION="1.1.4"
 
 # Install desired version of Terraform
 rm -f /usr/local/bin/terraform

--- a/instruqt-tracks/terraform-foundations-aws/track.yml
+++ b/instruqt-tracks/terraform-foundations-aws/track.yml
@@ -17,6 +17,7 @@ owner: hashicorp
 developers:
 - jlinn@hashicorp.com
 - troy@hashicorp.com
+- roger@hashicorp.com
 private: true
 published: true
 show_timer: true
@@ -61,7 +62,7 @@ challenges:
     workshop. As we build on this project, we will introduce more advanced concepts that will enable scalability, reusability, security and self service.
 
     All Terraform templates are written in either [<ins>**HCL**</ins>](https://github.com/hashicorp/hcl/blob/hcl2/hclsyntax/spec.md) or JSON. For today's labs, we will be using
-    HCL. In most cases you will need to define the [<ins>**provider(s)**</ins>](https://www.terraform.io/docs/providers/index.html) for the services that you want to provision
+    HCL. In most cases you will need to define the [<ins>**provider(s)**</ins>](https://registry.terraform.io/browse/providers) for the services that you want to provision
     changes to. We will cover what HCL is and what providers are in more detail below.
 
     Today we will be using AWS as our cloud provider and `us-east-2` as our desired region. There are multiple ways in which you can set up providers, depending on how you plan
@@ -606,7 +607,7 @@ challenges:
 
     You will need to define the following required values:
       - The subnet the instance be placed in, which we can determine from the network module defined above.
-      - The AMI ID, which you can obtain from the [data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami#image_id) definition.
+      - The AMI ID, which you can obtain from the [data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) definition.
       - The `created` tag which should be a timestamp created using a Terraform function. Check out the `Built-in Functions` tab to see which function you can use.
 
     ```
@@ -879,4 +880,4 @@ challenges:
     url: https://app.terraform.io
   difficulty: basic
   timelimit: 5000
-checksum: "8296701521441350551"
+checksum: "3095496004311683293"

--- a/instruqt-tracks/terraform-intro-aws/track.yml
+++ b/instruqt-tracks/terraform-intro-aws/track.yml
@@ -34,7 +34,8 @@ challenges:
       Setting up your environment...
       Keep an eye on the bottom right corner to know when you can get started.
   - type: text
-    contents: The Terraform command line tool is available for MacOS, FreeBSD, OpenBSD, Windows, Solaris and Linux.
+    contents: The Terraform command line tool is available for MacOS, FreeBSD, OpenBSD,
+      Windows, Solaris and Linux.
   - type: text
     contents: The Terraform language is designed to be both human and machine-readable.
   - type: text
@@ -250,7 +251,8 @@ challenges:
     Terraform has a built in validation tester. This is useful to see whether your Terraform code is valid and parses correctly.
   notes:
   - type: text
-    contents: Terraform has a built-in syntax checker. You can run it with the `terraform validate` command.
+    contents: Terraform has a built-in syntax checker. You can run it with the `terraform
+      validate` command.
   assignment: |-
     Terraform comes with a built-in subcommand called *validate*. This is useful when you want to do a quick syntax check of your code to make sure it parses correctly.
 
@@ -317,7 +319,8 @@ challenges:
     Terraform variables allow you to customize your infrastructure without editing any code. You can use the same Terraform code to deploy dev, staging and production but with different variables.
   notes:
   - type: text
-    contents: The `terraform.tfvars` file is a convenient place for users to configure their variables.
+    contents: The `terraform.tfvars` file is a convenient place for users to configure
+      their variables.
   assignment: |-
     In Terraform all variables must be declared (with or without an optional default value) before you can use them. Variables are usually declared in the "variables.tf" file although they can also be declared in other "*.tf" files. Their values can be set in the "terraform.tfvars" file and in other ways which we'll explore later.
 
@@ -407,7 +410,9 @@ challenges:
     Terraform creates a graph of all the infrastructure defined in your code.
   notes:
   - type: text
-    contents: Terraform Graph can provide a visual representation of all your infrastructure. This is handy for finding dependency issues or resources that will be affected by a change.
+    contents: Terraform Graph can provide a visual representation of all your infrastructure.
+      This is handy for finding dependency issues or resources that will be affected
+      by a change.
   assignment: |-
     Try running the `terraform graph` command:
 
@@ -567,11 +572,12 @@ challenges:
     Terraform can change some resources in in place without deleting them. Adding tags is a non-destructive action.
   notes:
   - type: text
-    contents: Adding, changing, or removing tags is a non-destructive action. Terraform can tag your resources without re-creating them.
+    contents: Adding, changing, or removing tags is a non-destructive action. Terraform
+      can tag your resources without re-creating them.
   assignment: |-
     Several resource types support AWS's tags. Read the Terraform documentation for the `aws_vpc` resource to learn about the `tags` argument and its format.
 
-    [Terraform Docs: the aws_vpc resource - Click Here](https://www.terraform.io/docs/providers/aws/r/vpc.html)
+    [Terraform Docs: the aws_vpc resource - Click Here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc)
 
     Add a tag to your VPC resource in the **main.tf** file. The name of the tag should be `environment` and the value should be `Production`. (The tag is case-sensitive. Make sure you use a capital P.)
 
@@ -598,7 +604,8 @@ challenges:
     Terraform resources are like building blocks. You can continue adding more blocks until your infrastructure reaches the desired state.
   notes:
   - type: text
-    contents: Terraform code can be built incrementally, one or two resources at a time.
+    contents: Terraform code can be built incrementally, one or two resources at a
+      time.
   assignment: |-
     Open the **main.tf** file again and uncomment the next resource block in the file. The type of resource is **aws_subnet** and it is named **hashicat**.
 
@@ -627,7 +634,8 @@ challenges:
     Terraform code can stand up everything from VPCs, to virtual networks, to VMs and containers.
   notes:
   - type: text
-    contents: The `-auto-approve` flag can be used to override the "Are you sure?" questions that appear before an apply or destroy. Use with caution!
+    contents: The `-auto-approve` flag can be used to override the "Are you sure?"
+      questions that appear before an apply or destroy. Use with caution!
   assignment: |-
     We've uncommented all the rest of the Terraform code in the **main.tf** file for you. Run a `terraform plan` to see what will be built:
 
@@ -718,9 +726,13 @@ challenges:
     Terraform works great with many different provisioning tools including Chef, Puppet, Ansible, Bash, and Powershell.
   notes:
   - type: text
-    contents: Terraform provisioners run once at creation time. They do not run on subsequent applies, except in special circumstances. (Like this training lab...)
+    contents: Terraform provisioners run once at creation time. They do not run on
+      subsequent applies, except in special circumstances. (Like this training lab...)
   - type: text
-    contents: We've made some special adjustments to force the provisioner to run every time you type terraform apply. This is so you can practice playing with provisioners without destroying and recreating your virtual machine every time you make a change.
+    contents: We've made some special adjustments to force the provisioner to run
+      every time you type terraform apply. This is so you can practice playing with
+      provisioners without destroying and recreating your virtual machine every time
+      you make a change.
   - type: text
     contents: |-
       ```
@@ -773,11 +785,15 @@ challenges:
     Outputs are used to convey useful information such as IP addresses, application URLs or other useful data.
   notes:
   - type: text
-    contents: You can mix plain text along with Terraform data in your outputs. Outputs can be used to convey useful information to your users at the end of a run.
+    contents: You can mix plain text along with Terraform data in your outputs. Outputs
+      can be used to convey useful information to your users at the end of a run.
   - type: text
-    contents: The `terraform refresh` command will sync your state file with what exists in your infrastructure. A refresh command will not change your infrastructure.
+    contents: The `terraform refresh` command will sync your state file with what
+      exists in your infrastructure. A refresh command will not change your infrastructure.
   - type: text
-    contents: The `terraform output` command can be run any time you want to see your Terraform outputs again. Run `terraform output <output_name>` to view a single output.
+    contents: The `terraform output` command can be run any time you want to see your
+      Terraform outputs again. Run `terraform output <output_name>` to view a single
+      output.
   assignment: |-
     Open the **outputs.tf** file on the "Code Editor" tab. Note the public_dns output in the file.
 
@@ -1027,4 +1043,4 @@ challenges:
     path: /root/hashicat-aws
   difficulty: basic
   timelimit: 1000
-checksum: "2794629006460356950"
+checksum: "190704902276224425"

--- a/instruqt-tracks/terraform-intro-aws/track_scripts/setup-workstation
+++ b/instruqt-tracks/terraform-intro-aws/track_scripts/setup-workstation
@@ -12,7 +12,7 @@ do
 done
 
 # Set Terraform Version
-TERRAFORM_VERSION="1.0.7"
+TERRAFORM_VERSION="1.1.4"
 
 # Install desired version of Terraform
 wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip

--- a/instruqt-tracks/terraform-intro-azure/track.yml
+++ b/instruqt-tracks/terraform-intro-azure/track.yml
@@ -33,7 +33,8 @@ challenges:
       Setting up your environment...
       Keep an eye on the bottom right corner to know when you can get started.
   - type: text
-    contents: The Terraform command line tool is available for MacOS, FreeBSD, OpenBSD, Windows, Solaris and Linux.
+    contents: The Terraform command line tool is available for MacOS, FreeBSD, OpenBSD,
+      Windows, Solaris and Linux.
   - type: text
     contents: The Terraform language is designed to be both human and machine-readable.
   - type: text
@@ -252,7 +253,8 @@ challenges:
     Terraform has a built in validation tester. This is useful to see whether your Terraform code is valid and parses correctly.
   notes:
   - type: text
-    contents: Terraform has a built-in syntax checker. You can run it with the `terraform validate` command.
+    contents: Terraform has a built-in syntax checker. You can run it with the `terraform
+      validate` command.
   assignment: |-
     Terraform comes with a built-in subcommand called **validate**. This is useful when you want to do a quick syntax check of your code to make sure it parses correctly.
 
@@ -319,7 +321,8 @@ challenges:
     Terraform variables allow you to customize your infrastructure without editing any code. You can use the same Terraform code to deploy dev, staging and production but with different variables.
   notes:
   - type: text
-    contents: The `terraform.tfvars` file is a convenient place for users to configure their variables.
+    contents: The `terraform.tfvars` file is a convenient place for users to configure
+      their variables.
   assignment: |-
     In Terraform all variables must be declared (with or without an optional default value) before you can use them. Variables are usually declared in the "variables.tf" file although they can also be declared in other "*.tf" files. Their values can be set in the "terraform.tfvars" file and in other ways which we'll explore later.
 
@@ -409,7 +412,9 @@ challenges:
     Terraform creates a graph of all the infrastructure defined in your code.
   notes:
   - type: text
-    contents: Terraform Graph can provide a visual representation of all your infrastructure. This is handy for finding dependency issues or resources that will be affected by a change.
+    contents: Terraform Graph can provide a visual representation of all your infrastructure.
+      This is handy for finding dependency issues or resources that will be affected
+      by a change.
   assignment: |-
     Try running the `terraform graph` command:
 
@@ -569,11 +574,12 @@ challenges:
     Terraform can change some resources in in place without deleting them. Adding tags is a non-destructive action.
   notes:
   - type: text
-    contents: Adding, changing, or removing tags is a non-destructive action. Terraform can tag your resources without re-creating them.
+    contents: Adding, changing, or removing tags is a non-destructive action. Terraform
+      can tag your resources without re-creating them.
   assignment: |-
     Read the Terraform documentation for the azurerm_resource_group resource:
 
-    [Azure Terraform Docs - Click Here](https://www.terraform.io/docs/providers/azurerm/r/resource_group.html)
+    [Azure Terraform Docs - Click Here](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group)
 
     Add a tag to your resource group in the **main.tf** file using the `tags` argument of the `azurerm_resource_group` resource.
 
@@ -602,7 +608,8 @@ challenges:
     Terraform resources are like building blocks. You can continue adding more blocks until your infrastructure reaches the desired state.
   notes:
   - type: text
-    contents: Terraform code can be built incrementally, one or two resources at a time.
+    contents: Terraform code can be built incrementally, one or two resources at a
+      time.
   assignment: |-
     Open the **main.tf** file again and uncomment the next resource block in the file. The type of resource is **azurerm_virtual_network** and it is named **vnet**.
 
@@ -631,7 +638,8 @@ challenges:
     Terraform code can stand up everything from resource groups, to virtual networks, to VMs and containers.
   notes:
   - type: text
-    contents: The `-auto-approve` flag can be used to override the "Are you sure?" questions that appear before an apply or destroy. Use with caution!
+    contents: The `-auto-approve` flag can be used to override the "Are you sure?"
+      questions that appear before an apply or destroy. Use with caution!
   assignment: |-
     We've uncommented all the rest of the Terraform code in the **main.tf** file for you. Run a `terraform plan` to see what will be built:
 
@@ -720,9 +728,13 @@ challenges:
     Terraform works great with many different provisioning tools including Chef, Puppet, Ansible, Bash, and Powershell.
   notes:
   - type: text
-    contents: Terraform provisioners run once at creation time. They do not run on subsequent applies, except in special circumstances. (Like this training lab...)
+    contents: Terraform provisioners run once at creation time. They do not run on
+      subsequent applies, except in special circumstances. (Like this training lab...)
   - type: text
-    contents: We've made some special adjustments to force the provisioner to run every time you type terraform apply. This is so you can practice playing with provisioners without destroying and recreating your virtual machine every time you make a change.
+    contents: We've made some special adjustments to force the provisioner to run
+      every time you type terraform apply. This is so you can practice playing with
+      provisioners without destroying and recreating your virtual machine every time
+      you make a change.
   - type: text
     contents: |-
       ```
@@ -774,11 +786,15 @@ challenges:
     Outputs are used to convey useful information such as IP addresses, application URLs or other useful data.
   notes:
   - type: text
-    contents: You can mix plain text along with Terraform data in your outputs. Outputs can be used to convey useful information to your users at the end of a run.
+    contents: You can mix plain text along with Terraform data in your outputs. Outputs
+      can be used to convey useful information to your users at the end of a run.
   - type: text
-    contents: The `terraform refresh` command will sync your state file with what exists in your infrastructure. A refresh command will not change your infrastructure.
+    contents: The `terraform refresh` command will sync your state file with what
+      exists in your infrastructure. A refresh command will not change your infrastructure.
   - type: text
-    contents: The `terraform output` command can be run any time you want to see your Terraform outputs again. Run `terraform output <output_name>` to view a single output.
+    contents: The `terraform output` command can be run any time you want to see your
+      Terraform outputs again. Run `terraform output <output_name>` to view a single
+      output.
   assignment: |-
     Open the **outputs.tf** file on the "Code Editor" tab.
 
@@ -788,7 +804,7 @@ challenges:
 
     You may refer to the docs page to see what types of outputs are valid:
 
-    [Terraform Azure Docs - Click Here](https://www.terraform.io/docs/providers/azurerm/r/public_ip.html#attributes-reference)
+    [Terraform Azure Docs - Click Here](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip#attributes-reference)
     [Terraform Outputs Docs - Click Here](https://www.terraform.io/docs/configuration/outputs.html)
 
     Be sure to save the changes to the **outputs.tf** file.
@@ -1030,4 +1046,4 @@ challenges:
     path: /root/hashicat-azure
   difficulty: basic
   timelimit: 1067
-checksum: "12765076196805009769"
+checksum: "16067465216838756912"

--- a/instruqt-tracks/terraform-intro-azure/track_scripts/setup-workstation
+++ b/instruqt-tracks/terraform-intro-azure/track_scripts/setup-workstation
@@ -12,7 +12,7 @@ do
 done
 
 # Set Terraform Version
-TERRAFORM_VERSION="1.0.7"
+TERRAFORM_VERSION="1.1.4"
 
 # Install desired version of Terraform
 wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip

--- a/instruqt-tracks/terraform-intro-gcp/track.yml
+++ b/instruqt-tracks/terraform-intro-gcp/track.yml
@@ -33,7 +33,8 @@ challenges:
       Setting up your environment...
       Keep an eye on the bottom right corner to know when you can get started.
   - type: text
-    contents: The Terraform command line tool is available for MacOS, FreeBSD, OpenBSD, Windows, Solaris and Linux.
+    contents: The Terraform command line tool is available for MacOS, FreeBSD, OpenBSD,
+      Windows, Solaris and Linux.
   - type: text
     contents: The Terraform language is designed to be both human and machine-readable.
   - type: text
@@ -245,7 +246,8 @@ challenges:
     Terraform has a built in validation tester. This is useful to see whether your Terraform code is valid and parses correctly.
   notes:
   - type: text
-    contents: Terraform has a built-in syntax checker. You can run it with the `terraform validate` command.
+    contents: Terraform has a built-in syntax checker. You can run it with the `terraform
+      validate` command.
   assignment: |-
     Terraform comes with a built-in subcommand called *validate*. This is useful when you want to do a quick syntax check of your code to make sure it parses correctly.
 
@@ -312,7 +314,8 @@ challenges:
     Terraform variables allow you to customize your infrastructure without editing any code. You can use the same Terraform code to deploy dev, staging and production but with different variables.
   notes:
   - type: text
-    contents: The `terraform.tfvars` file is a convenient place for users to configure their variables.
+    contents: The `terraform.tfvars` file is a convenient place for users to configure
+      their variables.
   assignment: |-
     In Terraform all variables must be declared (with or without an optional default value) before you can use them. Variables are usually declared in the "variables.tf" file although they can also be declared in other "*.tf" files. Their values can be set in the "terraform.tfvars" file and in other ways which we'll explore later.
 
@@ -402,7 +405,9 @@ challenges:
     Terraform creates a graph of all the infrastructure defined in your code.
   notes:
   - type: text
-    contents: Terraform Graph can provide a visual representation of all your infrastructure. This is handy for finding dependency issues or resources that will be affected by a change.
+    contents: Terraform Graph can provide a visual representation of all your infrastructure.
+      This is handy for finding dependency issues or resources that will be affected
+      by a change.
   assignment: |-
     Try running the `terraform graph` command:
 
@@ -563,7 +568,8 @@ challenges:
     Terraform resources are like building blocks. You can continue adding more blocks until your infrastructure reaches the desired state.
   notes:
   - type: text
-    contents: Terraform code can be built incrementally, one or two resources at a time.
+    contents: Terraform code can be built incrementally, one or two resources at a
+      time.
   assignment: |-
     Open the **main.tf** file again and uncomment the next resource block in the file. The type of resource is **google_compute_subnetwork** and it is named **hashicat**.
 
@@ -592,7 +598,8 @@ challenges:
     Terraform code can stand up everything from a GCP project, to virtual networks, to VMs and containers.
   notes:
   - type: text
-    contents: The `-auto-approve` flag can be used to override the "Are you sure?" questions that appear before an apply or destroy. Use with caution!
+    contents: The `-auto-approve` flag can be used to override the "Are you sure?"
+      questions that appear before an apply or destroy. Use with caution!
   assignment: |-
     We've uncommented the rest of the Terraform code in the **main.tf** file for you. Run a `terraform plan` to see what will be built:
 
@@ -683,9 +690,13 @@ challenges:
     Terraform works great with many different provisioning tools including Chef, Puppet, Ansible, Bash, and Powershell.
   notes:
   - type: text
-    contents: Terraform provisioners run once at creation time. They do not run on subsequent applies, except in special circumstances. (Like this training lab...)
+    contents: Terraform provisioners run once at creation time. They do not run on
+      subsequent applies, except in special circumstances. (Like this training lab...)
   - type: text
-    contents: We've made some special adjustments to force the provisioner to run every time you type terraform apply. This is so you can practice playing with provisioners without destroying and recreating your virtual machine every time you make a change.
+    contents: We've made some special adjustments to force the provisioner to run
+      every time you type terraform apply. This is so you can practice playing with
+      provisioners without destroying and recreating your virtual machine every time
+      you make a change.
   - type: text
     contents: |-
       ```
@@ -738,11 +749,15 @@ challenges:
     Outputs are used to convey useful information such as IP addresses, application URLs or other useful data.
   notes:
   - type: text
-    contents: You can mix plain text along with Terraform data in your outputs. Outputs can be used to convey useful information to your users at the end of a run.
+    contents: You can mix plain text along with Terraform data in your outputs. Outputs
+      can be used to convey useful information to your users at the end of a run.
   - type: text
-    contents: The `terraform refresh` command will sync your state file with what exists in your infrastructure. A refresh command will not change your infrastructure.
+    contents: The `terraform refresh` command will sync your state file with what
+      exists in your infrastructure. A refresh command will not change your infrastructure.
   - type: text
-    contents: The `terraform output` command can be run any time you want to see your Terraform outputs again. Run `terraform output <output_name>` to view a single output.
+    contents: The `terraform output` command can be run any time you want to see your
+      Terraform outputs again. Run `terraform output <output_name>` to view a single
+      output.
   assignment: |-
     Open the **outputs.tf** file on the "Code Editor" tab. Note the catapp_url output in the file.
 
@@ -752,7 +767,7 @@ challenges:
 
     You may refer to the docs page to see what types of outputs are valid:
 
-    [Terraform GCP Docs - Click Here](https://www.terraform.io/docs/providers/google/r/compute_instance.html#attributes-reference)
+    [Terraform GCP Docs - Click Here](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#attributes-reference)
     [Terraform Outputs Docs - Click Here](https://www.terraform.io/docs/configuration/outputs.html)
 
     Be sure to save the changes to the **outputs.tf** file.
@@ -990,4 +1005,4 @@ challenges:
     path: /root/hashicat-gcp
   difficulty: basic
   timelimit: 1000
-checksum: "7926536496804086966"
+checksum: "3454967643602368276"

--- a/instruqt-tracks/terraform-intro-gcp/track_scripts/setup-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/track_scripts/setup-workstation
@@ -12,7 +12,7 @@ do
 done
 
 # Set Terraform Version
-TERRAFORM_VERSION="1.0.7"
+TERRAFORM_VERSION="1.1.4"
 
 # Install desired version of Terraform
 wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip


### PR DESCRIPTION
Update TF to 1.1.4 in most tracks, but not yet in terraform-foundations-aws, terraform-cloud-bonus-lab, or in terraform-module-lab.

Also fix links to provider docs that were broken after they were moved to registry site.