### PR TITLE
Increasing timeout for OSS Azure track

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ jobs:
               echo "Instruqt track test failed three times."
               exit 1
             fi
+          no_output_timeout: 30m
   instruqt-test-cloud-aws:
     docker:
       - image: docker.mirror.hashicorp.services/ubuntu:latest


### PR DESCRIPTION
Extending extend the no-output timeout to 30m. Circle CI job is failing with:

```
==> Testing challenge [18/27] 'complete-the-build' (ID: qcvvtwcbkwoz)
    Setting up challenge              . OK
    Running check, expecting failure  SKIPPED
    Running solve                     

Too long with no output (exceeded 10m0s): context deadline exceeded
```
