### PR TITLE
adding no_output_timeout to truqt-test-cloud-azure track

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,6 +224,7 @@ jobs:
               echo "Instruqt track test failed three times."
               exit 1
             fi
+          no_output_timeout: 30m
   instruqt-test-cloud-gcp:
     docker:
       - image: docker.mirror.hashicorp.services/ubuntu:latest


### PR DESCRIPTION
Using the timeout override on truqt-test-cloud-azure track

```
Too long with no output (exceeded 10m0s): context deadline exceeded
```