### PR TITLE
Add instructions to account for new forking options in Github.

### DIFF
--- a/instruqt-tracks/terraform-cloud-aws/track.yml
+++ b/instruqt-tracks/terraform-cloud-aws/track.yml
@@ -706,6 +706,7 @@ challenges:
     Instead of writing this module from scratch you can copy the existing AWS s3-bucket module from the public Terraform registry. Visit this [URL](https://registry.terraform.io/modules/terraform-aws-modules/s3-bucket/aws) to view the s3-bucket module.
 
     Note the "Source Code" link that points at the GitHub repository for this module. Click on the Source URL. As you did in previous challenges, create your own fork of this repository with the "Fork" button.
+    Make sure you uncheck `Copy the master branch only` at the bottom of the **Create a new fork** page on Github so your fork contains tags that are used for publishing modules.
 
     Back in the Terraform Cloud UI, click on the "Registry" tab at the top of the page. Then click the "Publish" button and the "Module" button that appears beneath it. Click on the "GitHub" button and select the terraform-aws-s3-bucket repository that you just forked.
 

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -710,7 +710,11 @@ challenges:
 
     Instead of writing this module from scratch you can copy the existing Azure network module from the public Terraform registry. Visit this [URL](https://registry.terraform.io/modules/Azure/network/azurerm) to view the Azure Network module.
 
-    Note the "Source Code" link that points at the GitHub repository for this module. Click on the Source URL. As you did in previous challenges, create your own fork of this repository with the "Fork" button. Make sure you fork the `terraform-azurerm-network` module and NOT the `terraform-azurerm-vnet` module also linked on the page.
+    Note the "Source Code" link that points at the GitHub repository for this module. Click on the Source URL. As you did in previous challenges, create your own fork of this repository with the "Fork" button. Make sure you:
+
+    * Fork the `terraform-azurerm-network` module and NOT the `terraform-azurerm-vnet` module also linked on the page.
+    * Uncheck `Copy the master branch only` at the bottom of the **Create a new fork** page on Github so your fork contains tags that are used for publishing modules.
+
 
     Back in the Terraform Cloud UI, click on the "Registry" tab at the top of the page. Then click the "Publish" button and the "Module" button that appears beneath it. Click on the "GitHub" button and select the terraform-azurerm-network repository that you just forked.
 

--- a/instruqt-tracks/terraform-cloud-gcp/track.yml
+++ b/instruqt-tracks/terraform-cloud-gcp/track.yml
@@ -709,6 +709,8 @@ challenges:
     Instead of writing this module from scratch you can copy the existing vpc module from the public Terraform registry. Visit this [URL](https://registry.terraform.io/modules/terraform-google-modules/network/google) to view the VPC module.
 
     Note the "Source Code" link that points at the GitHub repository for this module. Click on the Source URL. As you did in previous challenges, create your own fork of this repository with the "Fork" button.
+    Make sure you uncheck `Copy the master branch only` at the bottom of the **Create a new fork** page on Github so your fork contains tags that are used for publishing modules.
+
 
     Back in the Terraform Cloud UI, click on the "Registry" tab at the top of the page. Then click the "Publish" button and the "Module" button that appears beneath it. Click on the "GitHub" button and select the terraform-google-network repository that you just forked.
 


### PR DESCRIPTION
By default a fork will copy the master branch only. None of the tags are copied and users get confused when no modules are published.

![image](https://user-images.githubusercontent.com/14114376/191264183-bf9a3146-4a9a-4a32-94a1-6ebef9555e08.png)
