### PR TITLE
Improve remote exec check

### DIFF
--- a/instruqt-tracks/terraform-cloud-aws/protecting-sensitive-variables/check-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/protecting-sensitive-variables/check-workstation
@@ -11,6 +11,8 @@ cd /root/hashicat-aws
 
 TOKEN=$(grep token /root/.terraform.d/credentials.tfrc.json | cut -d '"' -f4)
 
+echo $TOKEN | grep -q "atlasv1" || fail-message "Token not found in credentials.tfrc.json,  please run terraform login"
+
 # Test whether remote exec is enabled on the workspace.
 REMOTE_EXEC_ENABLED=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-aws | jq .data.attributes.operations)
 

--- a/instruqt-tracks/terraform-cloud-aws/track_scripts/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-aws/track_scripts/setup-workstation
@@ -30,7 +30,7 @@ cp /usr/games/cowsay /usr/local/bin/cowsay
 # clone the hashicat-aws repo
 git clone https://github.com/hashicorp/hashicat-aws
 GITDIR="/root/hashicat-aws"
-
+git config --global credential.helper "cache --timeout=86400"
 # Set workdir
 set-workdir /root/hashicat-aws
 

--- a/instruqt-tracks/terraform-cloud-azure/protecting-sensitive-variables/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/protecting-sensitive-variables/check-workstation
@@ -11,6 +11,8 @@ cd /root/hashicat-azure
 
 TOKEN=$(grep token /root/.terraform.d/credentials.tfrc.json | cut -d '"' -f4)
 
+echo $TOKEN | grep -q "atlasv1" || fail-message "Token not found in credentials.tfrc.json, please run terraform login"
+
 # Test whether remote exec is enabled on the workspace.
 REMOTE_EXEC_ENABLED=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-azure | jq .data.attributes.operations)
 

--- a/instruqt-tracks/terraform-cloud-azure/track_scripts/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/track_scripts/setup-workstation
@@ -30,6 +30,7 @@ cp /usr/games/cowsay /usr/local/bin/cowsay
 # clone the hashicat-azure repo
 git clone https://github.com/hashicorp/hashicat-azure
 GITDIR="/root/hashicat-azure"
+git config --global credential.helper "cache --timeout=86400"
 
 # Set workdir
 set-workdir /root/hashicat-azure

--- a/instruqt-tracks/terraform-cloud-gcp/protecting-sensitive-variables/check-workstation
+++ b/instruqt-tracks/terraform-cloud-gcp/protecting-sensitive-variables/check-workstation
@@ -11,7 +11,7 @@ cd /root/hashicat-gcp
 
 TOKEN=$(grep token /root/.terraform.d/credentials.tfrc.json | cut -d '"' -f4)
 
-# TODO: Rewrite these checks for GCP
+echo $TOKEN | grep -q "atlasv1" || fail-message "Token not found in credentials.tfrc.json,  please run terraform login"
 
 # Test whether remote exec is enabled on the workspace.
 REMOTE_EXEC_ENABLED=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://app.terraform.io/api/v2/organizations/$ORG/workspaces/hashicat-gcp | jq .data.attributes.operations)

--- a/instruqt-tracks/terraform-cloud-gcp/track_scripts/setup-workstation
+++ b/instruqt-tracks/terraform-cloud-gcp/track_scripts/setup-workstation
@@ -30,6 +30,8 @@ cp /usr/games/cowsay /usr/local/bin/cowsay
 # clone the hashicat-gcp repo
 git clone https://github.com/hashicorp/hashicat-gcp
 GITDIR="/root/hashicat-gcp"
+git config --global credential.helper "cache --timeout=86400"
+
 
 # Set workdir
 set-workdir /root/hashicat-gcp


### PR DESCRIPTION
* Check if valid token is supplied before validating execution mode
* Cache git credentials so participants don't have to re-enter them