### PR TITLE
Update to a region that supports B1s VMs in all zones for new subscriptions.

### DIFF
--- a/instruqt-tracks/terraform-cloud-azure/oh-no-an-outage/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/oh-no-an-outage/solve-workstation
@@ -67,7 +67,7 @@ curl --header "Authorization: Bearer $TOKEN" --header "Content-Type: application
 export PREFIX=hashicat-$RANDOM
 echo "export PREFIX=$PREFIX" >> /root/.bashrc
 echo -e "prefix = \"$PREFIX\"" > terraform.tfvars
-echo -e "location = \"centralus\"" >> terraform.tfvars
+echo -e "location = \"eastus\"" >> terraform.tfvars
 
 # Run terraform init and apply
 terraform init

--- a/instruqt-tracks/terraform-cloud-azure/protecting-sensitive-variables/solve-workstation
+++ b/instruqt-tracks/terraform-cloud-azure/protecting-sensitive-variables/solve-workstation
@@ -163,7 +163,7 @@ cat <<-EOF > /tmp/location.json
     "type":"vars",
     "attributes": {
       "key":"location",
-      "value":"centralus",
+      "value":"eastus",
       "category":"terraform",
       "hcl":false,
       "sensitive":false

--- a/instruqt-tracks/terraform-cloud-azure/track.yml
+++ b/instruqt-tracks/terraform-cloud-azure/track.yml
@@ -171,6 +171,8 @@ challenges:
 
     See this [page](https://azure.microsoft.com/en-us/global-infrastructure/geographies/) for a list of valid Azure locations (which shows the longer names with spaces).
 
+    (**Note that not all Azure regions support all VM types**; if you get an error about the SKU failing because of capacity restrictions when you run the Terraform commands below, try changing to a different region.)
+
     Uncomment the variable values by removing "# " from each line. Be sure to save the file after editing it.
 
     The variables are actually declared in the "variables.tf" file. The "terraform.tfvars" file is just being used to set values for them.
@@ -190,7 +192,7 @@ challenges:
 
     Outputs:
     catapp_ip = "http://"
-    catapp_url = http://sean-carolan-meow.centralus.cloudapp.azure.com
+    catapp_url = http://sean-carolan-meow.eastus.cloudapp.azure.com
     ```
     Please click on the second URL to test that your application is working.
 

--- a/instruqt-tracks/terraform-intro-azure/terraform-add-a-variable/solve-workstation
+++ b/instruqt-tracks/terraform-intro-azure/terraform-add-a-variable/solve-workstation
@@ -6,6 +6,6 @@ set -o history
 
 cd /root/hashicat-azure
 
-echo -e "location=\"centralus\"" >> terraform.tfvars
+echo -e "location=\"eastus\"" >> terraform.tfvars
 
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/track.yml
+++ b/instruqt-tracks/terraform-intro-azure/track.yml
@@ -362,11 +362,13 @@ challenges:
     terraform plan
     ```
 
-    Choose an Azure location near to you but different from the default one which is "centralus". Add a `location` variable to your "terraform.tfvars" file, setting it to your desired location such as `East US`, `UK South`, or `Southeast Asia`. You can also use shorter names like `eastus`, `uksouth`, or `southeastasia`; in fact, Terraform will convert the longer names with spaces to the shorter names without them.
+    Choose an Azure location near to you but different from the default one which is "eastus". Add a `location` variable to your "terraform.tfvars" file, setting it to your desired location such as `East US`, `UK South`, or `Southeast Asia`. You can also use shorter names like `eastus`, `uksouth`, or `southeastasia`; in fact, Terraform will convert the longer names with spaces to the shorter names without them.
 
     See this [page](https://azure.microsoft.com/en-us/global-infrastructure/geographies/) for a list of valid Azure locations (which shows the longer names with spaces).
 
     Choosing a location close to you can help improve speed and performance.
+
+    (**Note that not all Azure regions support all VM types**; if you get an error about the SKU failing because of capacity restrictions when you run the Terraform commands below, try changing to a different region.)
 
     **Be sure to click the disk icon above the file to save your change!**
 


### PR DESCRIPTION
Azure has (apparently) stopped allowing new subscriptions to provision Standard_B1s VMs in Central US; while this doesn't technically break the Azure Terraform tracks, it does break the test automation which currently uses centralus.  Additionally, it complicates the user experience since the text refers to centralus as the default in examples.

We probably should really look at whether a new VM type is more suitable for all-region use but for now, just changing the region (and adding a warning to the user about the situation in case they try to use a region that isn't suitable) is a quick fix.