### PR TITLE
IL-709 Fix issues with Terraform state locking and stale processes

### DIFF
--- a/instruqt-tracks/terraform-intro-gcp/add-an-output/check-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/add-an-output/check-workstation
@@ -8,9 +8,16 @@ if [ -f /tmp/skip-check ]; then
 fi
 
 cd /root/hashicat-gcp
+
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 OUTPUT=$(cat terraform.tfstate | jq -r .outputs.catapp_ip.value)
 
-if [ -z $OUTPUT ]; then
+if [ -z "$OUTPUT" ]; then
   fail-message "We didn't find your catapp_ip output. Try again."
 fi
 

--- a/instruqt-tracks/terraform-intro-gcp/add-virtual-network/check-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/add-virtual-network/check-workstation
@@ -9,10 +9,16 @@ fi
 
 cd /root/hashicat-gcp
 
+# Is Terraform still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 # Check state file for network
 SUBNET=$(cat terraform.tfstate | jq -r '.resources[] | select(.type == "google_compute_subnetwork") | .type')
 
-if [ $SUBNET != "google_compute_subnetwork" ]; then
+if [ "$SUBNET" != "google_compute_subnetwork" ]; then
   fail-message "We didn't find your google_compute_subnetwork resource. Try again."
 fi
 

--- a/instruqt-tracks/terraform-intro-gcp/complete-the-build/check-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/complete-the-build/check-workstation
@@ -9,8 +9,23 @@ fi
 
 cd /root/hashicat-gcp
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+# Ensure `catapp_url` is defined in Terraform putouts
+CATAPP_URL=$(terraform output -raw catapp_url 2>/dev/null)
+if [ -z "$CATAPP_URL" ]; then
+    fail-message "catapp_url not defined, try provisioning it again"
+fi
+
 # Fetch the URL and grep the HTTP code for "200 OK"
 # Add retries in case the website isn't up and running yet.
-curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 60 -I $(cat terraform.tfstate | jq -r .outputs.catapp_url.value) | grep "200 OK" || fail-message "We were unable to load your web app. Try provisioning it again."
+CATAPP_STATUS=$(curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 60 -o /dev/null -s -w '%{http_code}' "$CATAPP_URL")
+if [ "$CATAPP_STATUS" != "200" ]; then
+    fail-message "We were unable to load your web app. Try provisioning it again."
+fi
 
 exit 0

--- a/instruqt-tracks/terraform-intro-gcp/configure-remote-state/check-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/configure-remote-state/check-workstation
@@ -7,4 +7,10 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 exit 0

--- a/instruqt-tracks/terraform-intro-gcp/fun-with-variables/check-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/fun-with-variables/check-workstation
@@ -7,4 +7,10 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 exit 0

--- a/instruqt-tracks/terraform-intro-gcp/terraform-destroy/check-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/terraform-destroy/check-workstation
@@ -9,6 +9,12 @@ fi
 
 cd /root/hashicat-gcp
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 RESOURCES=$(cat terraform.tfstate | jq '.resources | .[]')
 
 if [ ! -z $RESOURCES ]; then

--- a/instruqt-tracks/terraform-intro-gcp/tf-graph/check-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/tf-graph/check-workstation
@@ -7,7 +7,16 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-# Fix this after getting the solve script working.
-curl -I http://localhost:5000 | grep -q "HTTP/1.0 200 OK" || fail-message "Oops, it looks like the Blast Radius tool is not running."
+# Make sure user actually started blast-radius
+BR_PID=$(lsof -i :5000 -F p |awk '/^p/{print substr($1,2);}')
+if [ -z "$BR_PID" ]; then
+    fail-message "Looks like Blast Radius is not running, please start it"
+else
+    # And now shut it down, since we rely on it *not* being running
+    # later on, and thanks to IL-710 and related, Instruqt doesn't
+    # reliably shut down processes when you move from one challenge
+    # to another
+    kill ${BR_PID}
+fi
 
 exit 0

--- a/instruqt-tracks/terraform-intro-gcp/tf-graph/check-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/tf-graph/check-workstation
@@ -11,12 +11,6 @@ fi
 BR_PID=$(lsof -i :5000 -F p |awk '/^p/{print substr($1,2);}')
 if [ -z "$BR_PID" ]; then
     fail-message "Looks like Blast Radius is not running, please start it"
-else
-    # And now shut it down, since we rely on it *not* being running
-    # later on, and thanks to IL-710 and related, Instruqt doesn't
-    # reliably shut down processes when you move from one challenge
-    # to another
-    kill ${BR_PID}
 fi
 
 exit 0

--- a/instruqt-tracks/terraform-intro-gcp/tf-graph/cleanup-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/tf-graph/cleanup-workstation
@@ -1,0 +1,14 @@
+#!/bin/bash -l
+set -e
+
+# Shut down Blast Radius, since we assume it isn't running later
+# on, but didn't ask the user to stop it
+BR_PID=$(lsof -i :5000 -F p |awk '/^p/{print substr($1,2);}')
+if [ -z "$BR_PID" ]; then
+    # It wasn't running anyways, so just exit
+    exit 0
+else
+    kill ${BR_PID}
+fi
+
+exit 0

--- a/instruqt-tracks/terraform-intro-gcp/track.yml
+++ b/instruqt-tracks/terraform-intro-gcp/track.yml
@@ -578,11 +578,14 @@ challenges:
 
     Uncomment the code by removing the `#` characters from the beginning of each line. Be sure to save the file.
 
-    Now run `terraform apply` again. Observe the results.
+    Now run `terraform plan` and observe the results.
 
     Look at the **network** parameter inside the google_compute_subnetwork resource. See how it points back at the first resource in the file? The subnet resource inherits settings from the VPC network.
 
     Terraform can map out the complex web of dependencies between hundreds of interconnected resources.
+
+    Finally, create your Virtual Network. Run `terraform apply` and answer "yes" when prompted.
+
   tabs:
   - title: Shell
     type: terminal

--- a/instruqt-tracks/terraform-intro-gcp/use-a-provisioner/check-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/use-a-provisioner/check-workstation
@@ -9,6 +9,12 @@ fi
 
 cd /root/hashicat-gcp
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 grep -q "cowsay" main.tf || fail-message "We couldn't find the cowsay install commands in your provisioner inline list."
 
 exit 0


### PR DESCRIPTION
See https://support.instruqt.com/support/tickets/137 --- we can no longer rely on Instruqt to stop all shell tab processes as you move from one challenge to another, which causes two problems with this track: 1) users sometimes check whilst a Terraform command is still running, which causes subsequent confusion when they run `terraform` again and get error messages about the state being locked; 2) We tell users to start `blast-radius`, which may be running when we tell them later on to start it again, and they get port already in use errors.

* Where we run `terraform` commands in a challenge, update the check script to ensure that Terraform is not still running
* Fix a bash error which was causing a check for `google_compute_subnetwork` to fail because we did not quote what could be an empty string
* Make some checks a little more robust
* In the `tf-graph` challenge
  * Make the check for it running more robust
  * And then if it *is* running, shut it down so we do not get errors later on
* Clarify instructions in the `add-virtual-network` challenge