### PR TITLE
IL-719 Fix issues with Terraform state locking and stale processes

### DIFF
--- a/instruqt-tracks/terraform-intro-aws/add-a-tag/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/add-a-tag/check-workstation
@@ -10,13 +10,16 @@ fi
 # Checks the state file to make sure the student has added a tag.
 cd /root/hashicat-aws
 
-# Apply
-terraform apply -auto-approve
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
 
 # Check for tags
 TAG=$(cat terraform.tfstate | jq -r '.resources[] | select(.type == "aws_vpc")| .instances[] | .attributes | .tags | .environment')
 
-if [ $TAG != "Production" ]; then
+if [ "$TAG" != "Production" ]; then
    fail-message "You haven't added your Production environment tag yet."
 fi
 

--- a/instruqt-tracks/terraform-intro-aws/add-a-tag/solve-workstation
+++ b/instruqt-tracks/terraform-intro-aws/add-a-tag/solve-workstation
@@ -9,4 +9,6 @@ cd /root/hashicat-aws
 # sed -i '19 a \ \ \ \ environment = "Production"' main.tf
 sed -i 's/name = "\${var\.prefix}-vpc-\${var\.region}"/name = "\${var.prefix}-vpc-\${var.region}"\n    environment = "Production"/' main.tf
 
+terraform apply -auto-approve
+
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/add-an-output/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/add-an-output/check-workstation
@@ -8,9 +8,16 @@ if [ -f /tmp/skip-check ]; then
 fi
 
 cd /root/hashicat-aws
+
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 OUTPUT=$(cat terraform.tfstate | jq -r .outputs.catapp_ip.value)
 
-if [ -z $OUTPUT ]; then
+if [ -z "$OUTPUT" ]; then
   fail-message "We didn't find your catapp_ip output. Try again."
 fi
 

--- a/instruqt-tracks/terraform-intro-aws/add-virtual-network/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/add-virtual-network/check-workstation
@@ -9,10 +9,16 @@ fi
 
 cd /root/hashicat-aws
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 # Check state file for vnet
 VNET=$(cat terraform.tfstate | jq -r '.resources[] | select(.type == "aws_subnet") | .type')
 
-if [ $VNET != "aws_subnet" ]; then
+if [ "$VNET" != "aws_subnet" ]; then
   fail-message "We didn't find your aws_subnet resource. Try again."
 fi
 

--- a/instruqt-tracks/terraform-intro-aws/add-virtual-network/solve-workstation
+++ b/instruqt-tracks/terraform-intro-aws/add-virtual-network/solve-workstation
@@ -9,7 +9,8 @@ cd /root/hashicat-aws
 sed -i 's/# resource "aws_subnet" "hashicat" {/resource "aws_subnet" "hashicat" {/' main.tf
 sed -i 's/#   vpc_id     = aws_vpc.hashicat.id/  vpc_id     = aws_vpc.hashicat.id/' main.tf
 sed -i 's/#   cidr_block = var.subnet_prefix/  cidr_block = var.subnet_prefix/' main.tf
-sed -i 's/#   tags = {/  tags = {/' main.tf
+# Uncomment only the *first* tags line
+sed -i '0,/#   tags/{s/# //}' main.tf
 sed -i 's/#     name = "\${var.prefix}-subnet"/    name = "\${var.prefix}-subnet"/' main.tf
 sed -i '0,/#   }/{s/#   }/  }/}' main.tf
 sed -i '0,/# }/{s/# }/}/}' main.tf

--- a/instruqt-tracks/terraform-intro-aws/change-prefix/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/change-prefix/check-workstation
@@ -9,4 +9,10 @@ fi
 
 cd /root/hashicat-aws
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/complete-the-build/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/complete-the-build/check-workstation
@@ -9,8 +9,23 @@ fi
 
 cd /root/hashicat-aws
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+# Ensure `catapp_url` is defined in Terraform putouts
+CATAPP_URL=$(terraform output -raw catapp_url 2>/dev/null)
+if [ -z "$CATAPP_URL" ]; then
+    fail-message "catapp_url not defined, try provisioning it again"
+fi
+
 # Fetch the URL and grep the HTTP code for "200 OK"
 # Add retries in case the website isn't up and running yet.
-curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 60 -I $(cat terraform.tfstate | jq -r .outputs.catapp_url.value) | grep "200 OK" || fail-message "We were unable to load your web app. Try provisioning it again."
+CATAPP_STATUS=$(curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 60 -o /dev/null -s -w '%{http_code}' "$CATAPP_URL")
+if [ "$CATAPP_STATUS" != "200" ]; then
+    fail-message "We were unable to load your web app. Try provisioning it again."
+fi
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/configure-remote-state/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/configure-remote-state/check-workstation
@@ -7,4 +7,10 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/fun-with-variables/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/fun-with-variables/check-workstation
@@ -7,4 +7,10 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/terraform-add-a-variable/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/terraform-add-a-variable/check-workstation
@@ -7,6 +7,12 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 grep -q "region" /root/hashicat-aws/terraform.tfvars || fail-message "Oops, it looks like you haven't added your region to terraform.tfvars yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/terraform-cloud-setup/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/terraform-cloud-setup/check-workstation
@@ -7,4 +7,10 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/terraform-destroy/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/terraform-destroy/check-workstation
@@ -9,9 +9,15 @@ fi
 
 cd /root/hashicat-aws
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 RESOURCES=$(cat terraform.tfstate | jq '.resources | .[]')
 
-if [ ! -z $RESOURCES ]; then
+if [ ! -z "$RESOURCES" ]; then
   fail-message "Oops, looks like you still have some resources. Try running `terraform destroy` again."
 fi
 

--- a/instruqt-tracks/terraform-intro-aws/terraform-init-provider/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/terraform-init-provider/check-workstation
@@ -7,6 +7,12 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 [ -d /root/hashicat-aws/.terraform ] || fail-message "Oops, you haven't run terraform init yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/terraform-plan/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/terraform-plan/check-workstation
@@ -7,6 +7,12 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 # grep -q "terraform plan" /root/.bash_history || fail-message "You haven't run terraform plan yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/terraform-validate/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/terraform-validate/check-workstation
@@ -7,6 +7,12 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 cd /root/hashicat-aws
 terraform validate || fail-message "Oops, it looks like there is still an error in your Terraform code."
 

--- a/instruqt-tracks/terraform-intro-aws/terraform-variables/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/terraform-variables/check-workstation
@@ -7,6 +7,12 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 grep -qL "yourname" /root/hashicat-aws/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/tf-graph/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/tf-graph/check-workstation
@@ -7,7 +7,16 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-# Fix this after getting the solve script working.
-curl -I http://localhost:5000 | grep -q "HTTP/1.0 200 OK" || fail-message "Oops, it looks like the Blast Radius tool is not running."
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+# Make sure user actually started blast-radius
+BR_PID=$(lsof -i :5000 -F p |awk '/^p/{print substr($1,2);}')
+if [ -z "$BR_PID" ]; then
+    fail-message "Looks like Blast Radius is not running, please start it"
+fi
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/tf-graph/cleanup-workstation
+++ b/instruqt-tracks/terraform-intro-aws/tf-graph/cleanup-workstation
@@ -1,0 +1,14 @@
+#!/bin/bash -l
+set -e
+
+# Shut down Blast Radius, since we assume it isn't running later
+# on, but didn't ask the user to stop it
+BR_PID=$(lsof -i :5000 -F p |awk '/^p/{print substr($1,2);}')
+if [ -z "$BR_PID" ]; then
+    # It wasn't running anyways, so just exit
+    exit 0
+else
+    kill ${BR_PID}
+fi
+
+exit 0

--- a/instruqt-tracks/terraform-intro-aws/tf-plan-again/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/tf-plan-again/check-workstation
@@ -7,6 +7,12 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 # grep -q "terraform plan" /root/.bash_history || fail-message "You have not re-run terraform plan yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/tf-plan-and-apply/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/tf-plan-and-apply/check-workstation
@@ -7,6 +7,12 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 cd /root/hashicat-aws
 if [ ! -f terraform.tfstate ]; then
   fail-message "Oops, it looks like you haven't run terraform apply yet."

--- a/instruqt-tracks/terraform-intro-aws/track.yml
+++ b/instruqt-tracks/terraform-intro-aws/track.yml
@@ -586,7 +586,7 @@ challenges:
 
     Hint: Read the examples carefully! Unlike the other resource arguments you've seen, the value of the `tags` argument must be a **map** (a `{key = "value"}` data structure). Additionally, you must use `=` after `tags` and after `environment`. For more about Terraform's data types, see the [Terraform language documentation](https://www.terraform.io/docs/configuration/expressions.html#types-and-values).
 
-    Re-run `terraform apply`.
+    Re-run `terraform apply` and answer "yes" when prompted.
 
     What happens?
   tabs:
@@ -614,7 +614,7 @@ challenges:
 
     Uncomment the code by removing the `#` characters from the beginning of each line. Be sure to save the file.
 
-    Now run `terraform apply` again. Observe the results.
+    Now run `terraform apply` again and answer "yes" when prompted. Observe the results.
 
     Look at the **vpc_id** parameter inside the aws_subnet resource. See how it points back at the first resource in the file? The subnet resource inherits settings from the VPC.
 

--- a/instruqt-tracks/terraform-intro-aws/use-a-provisioner/check-workstation
+++ b/instruqt-tracks/terraform-intro-aws/use-a-provisioner/check-workstation
@@ -9,6 +9,12 @@ fi
 
 cd /root/hashicat-aws
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 grep -q "cowsay" main.tf || fail-message "We couldn't find the cowsay install commands in your provisioner inline list."
 
 exit 0


### PR DESCRIPTION
See https://support.instruqt.com/support/tickets/137 --- we can no longer rely on Instruqt to stop all shell tab processes as you move from one challenge to another, which causes two problems with this track: 1) users sometimes check whilst a Terraform command is still running, which causes subsequent confusion when they run `terraform` again and get error messages about the state being locked; 2) We tell users to start `blast-radius`, which may be running when we tell them later on to start it again, and they get port already in use errors.

 * Where we run `terraform` commands in a challege, ensure in the check script that Terraform is no longer running
 * After we tell users to start `blast-radius`, but do not tell them to stop it, but rely on it not running later, use a challenge cleanup script to stop it
 * Make some checks a bit more robust
 * Fix some Bash quoting errors which could lead to silent failures
 * Slight clarification on some instructions