### PR TITLE
IL-718 Fix issues with Terraform state locking and stale processes

### DIFF
--- a/instruqt-tracks/terraform-intro-azure/add-a-tag/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/add-a-tag/check-workstation
@@ -10,13 +10,16 @@ fi
 # Checks the state file to make sure the student has added a tag.
 cd /root/hashicat-azure
 
-# Apply
-terraform apply -auto-approve
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
 
 # Check for tags
 TAG=$(cat terraform.tfstate | jq -r '.resources[] | select(.type == "azurerm_resource_group")| .instances[] | .attributes | .tags | .environment')
 
-if [ $TAG != "Production" ]; then
+if [ "$TAG" != "Production" ]; then
    fail-message "You haven't added your Production environment tag yet."
 fi
 

--- a/instruqt-tracks/terraform-intro-azure/add-a-tag/solve-workstation
+++ b/instruqt-tracks/terraform-intro-azure/add-a-tag/solve-workstation
@@ -8,4 +8,6 @@ cd /root/hashicat-azure
 
 sed -i 's/^  tags = {}/  tags = {\n   environment = "Production"\n  }/' main.tf
 
+terraform apply -auto-approve
+
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/add-an-output/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/add-an-output/check-workstation
@@ -8,9 +8,16 @@ if [ -f /tmp/skip-check ]; then
 fi
 
 cd /root/hashicat-azure
+
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 OUTPUT=$(cat terraform.tfstate | jq -r .outputs.catapp_ip.value)
 
-if [ -z $OUTPUT ]; then
+if [ -z "$OUTPUT" ]; then
   fail-message "We didn't find your catapp_ip output. Try again."
 fi
 

--- a/instruqt-tracks/terraform-intro-azure/add-virtual-network/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/add-virtual-network/check-workstation
@@ -9,10 +9,17 @@ fi
 
 cd /root/hashicat-azure
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+
 # Check state file for vnet
 VNET=$(cat terraform.tfstate | jq -r '.resources[] | select(.type == "azurerm_virtual_network") | .type')
 
-if [ $VNET != "azurerm_virtual_network" ]; then
+if [ "$VNET" != "azurerm_virtual_network" ]; then
   fail-message "We didn't find your azurerm_virtual_network resource. Try again."
 fi
 

--- a/instruqt-tracks/terraform-intro-azure/add-virtual-network/solve-workstation
+++ b/instruqt-tracks/terraform-intro-azure/add-virtual-network/solve-workstation
@@ -10,7 +10,8 @@ sed -i 's/# resource "azurerm_virtual_network" "vnet" {/resource "azurerm_virtua
 sed -i 's/#   name                = "\${var.prefix}-vnet"/  name                = "\${var.prefix}-vnet"/' main.tf
 sed -i 's/#   location            = azurerm_resource_group.myresourcegroup.location/  location            = azurerm_resource_group.myresourcegroup.location/' main.tf
 sed -i 's/#   address_space       = \[var.address_space\]/  address_space       = [var.address_space]/' main.tf
-sed -i 's/#   resource_group_name = azurerm_resource_group.myresourcegroup.name/  resource_group_name = azurerm_resource_group.myresourcegroup.name/' main.tf
+# Replace only the *first* instance of a commented out `resource_group_name` line
+sed -i '0,/#   resource_group_name/{s/# //}' main.tf
 sed -i '0,/# }/{s/# }/}/}' main.tf
 
 terraform apply -auto-approve

--- a/instruqt-tracks/terraform-intro-azure/change-prefix/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/change-prefix/check-workstation
@@ -9,4 +9,11 @@ fi
 
 cd /root/hashicat-azure
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/complete-the-build/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/complete-the-build/check-workstation
@@ -9,6 +9,21 @@ fi
 
 cd /root/hashicat-azure
 
-curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 60 -I $(cat terraform.tfstate | jq -r .outputs.catapp_url.value) | grep "200 OK" || fail-message "We were unable to load your web app. Try provisioning it again."
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+# Ensure `catapp_url` is defined in Terraform putouts
+CATAPP_URL=$(terraform output -raw catapp_url 2>/dev/null)
+if [ -z "$CATAPP_URL" ]; then
+    fail-message "catapp_url not defined, try provisioning it again"
+fi
+
+CATAPP_STATUS=$(curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 60 -o /dev/null -s -w '%{http_code}' "$CATAPP_URL")
+if [ "$CATAPP_STATUS" != "200" ]; then
+    fail-message "We were unable to load your web app. Try provisioning it again."
+fi
 
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/configure-remote-state/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/configure-remote-state/check-workstation
@@ -7,4 +7,11 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/fun-with-variables/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/fun-with-variables/check-workstation
@@ -7,4 +7,11 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/hello-terraform/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/hello-terraform/check-workstation
@@ -7,6 +7,12 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 # grep -q "terraform version" /root/.bash_history || fail-message "You haven't run terraform version yet."
 
 # grep -q "terraform help" /root/.bash_history || fail-message "You haven't run terraform help yet."

--- a/instruqt-tracks/terraform-intro-azure/terraform-add-a-variable/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/terraform-add-a-variable/check-workstation
@@ -7,6 +7,13 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+
 grep -q "location" /root/hashicat-azure/terraform.tfvars || fail-message "Oops, it looks like you haven't added your location to terraform.tfvars yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/terraform-cloud-setup/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/terraform-cloud-setup/check-workstation
@@ -7,4 +7,10 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/terraform-destroy/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/terraform-destroy/check-workstation
@@ -9,6 +9,13 @@ fi
 
 cd /root/hashicat-azure
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+
 RESOURCES=$(cat terraform.tfstate | jq '.resources | .[]')
 
 if [ ! -z $RESOURCES ]; then

--- a/instruqt-tracks/terraform-intro-azure/terraform-init-provider/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/terraform-init-provider/check-workstation
@@ -7,6 +7,13 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+
 [ -d /root/hashicat-azure/.terraform ] || fail-message "Oops, you haven't run terraform init yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/terraform-plan/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/terraform-plan/check-workstation
@@ -7,6 +7,13 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+
 # grep -q "terraform plan" /root/.bash_history || fail-message "You haven't run terraform plan yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/terraform-validate/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/terraform-validate/check-workstation
@@ -7,6 +7,13 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+
 cd /root/hashicat-azure
 terraform validate || fail-message "Oops, it looks like there is still an error in your Terraform code."
 

--- a/instruqt-tracks/terraform-intro-azure/terraform-variables/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/terraform-variables/check-workstation
@@ -7,6 +7,13 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+
 grep -qL "yourname" /root/hashicat-azure/terraform.tfvars && fail-message "Oops, it looks like you haven't updated your prefix variable yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/tf-graph/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/tf-graph/check-workstation
@@ -7,7 +7,16 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-# Fix this after getting the solve script working.
-curl -I http://localhost:5000 | grep -q "HTTP/1.0 200 OK" || fail-message "Oops, it looks like the Blast Radius tool is not running."
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+# Make sure user actually started blast-radius
+BR_PID=$(lsof -i :5000 -F p |awk '/^p/{print substr($1,2);}')
+if [ -z "$BR_PID" ]; then
+    fail-message "Looks like Blast Radius is not running, please start it"
+fi
 
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/tf-graph/cleanup-workstation
+++ b/instruqt-tracks/terraform-intro-azure/tf-graph/cleanup-workstation
@@ -1,0 +1,14 @@
+#!/bin/bash -l
+set -e
+
+# Shut down Blast Radius, since we assume it isn't running later
+# on, but didn't ask the user to stop it
+BR_PID=$(lsof -i :5000 -F p |awk '/^p/{print substr($1,2);}')
+if [ -z "$BR_PID" ]; then
+    # It wasn't running anyways, so just exit
+    exit 0
+else
+    kill ${BR_PID}
+fi
+
+exit 0

--- a/instruqt-tracks/terraform-intro-azure/tf-plan-again/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/tf-plan-again/check-workstation
@@ -7,6 +7,13 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+
 # grep -q "terraform plan" /root/.bash_history || fail-message "You have not re-run terraform plan yet."
 
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/tf-plan-and-apply/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/tf-plan-and-apply/check-workstation
@@ -8,13 +8,20 @@ if [ -f /tmp/skip-check ]; then
 fi
 
 cd /root/hashicat-azure
+
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
 if [ ! -f terraform.tfstate ]; then
   fail-message "Oops, it looks like you haven't run terraform apply yet."
 fi
 
 MYRG=$(cat terraform.tfstate | jq -r '.resources | .[].name')
 
-if [ $MYRG != "myresourcegroup" ]; then
+if [ "$MYRG" != "myresourcegroup" ]; then
   fail-message "It looks like your resource group has not been built yet. Please try again."
 fi
 

--- a/instruqt-tracks/terraform-intro-azure/track.yml
+++ b/instruqt-tracks/terraform-intro-azure/track.yml
@@ -620,7 +620,7 @@ challenges:
 
     Uncomment the code by removing the `#` characters from the beginning of each line. Be sure to save the file.
 
-    Now run `terraform apply` again. Observe the results.
+    Now run `terraform apply` again and answer "yes" when prompted. Observe the results.
 
     Look at the **location** and **resource_group_name** parameters inside the vnet resource. See how they point back at the first resource in the file? The virtual network resource inherits settings from the resource group.
 

--- a/instruqt-tracks/terraform-intro-azure/use-a-provisioner/check-workstation
+++ b/instruqt-tracks/terraform-intro-azure/use-a-provisioner/check-workstation
@@ -9,6 +9,13 @@ fi
 
 cd /root/hashicat-azure
 
+# Make sure Terraform is not still running
+
+if [ -f .terraform.tfstate.lock.info ]; then
+    fail-message "Terraform is still running, please wait for it to finish."
+fi
+
+
 grep -q "cowsay" main.tf || fail-message "We couldn't find the cowsay install commands in your provisioner inline list."
 
 exit 0


### PR DESCRIPTION
See https://support.instruqt.com/support/tickets/137 --- we can no longer rely on Instruqt to stop all shell tab processes as you move from one challenge to another, which causes two problems with this track: 1) users sometimes check whilst a Terraform command is still running, which causes subsequent confusion when they run `terraform` again and get error messages about the state being locked; 2) We tell users to start `blast-radius`, which may be running when we tell them later on to start it again, and they get port already in use errors.

 * Where we run `terraform` commands in a challege, ensure in the check script that Terraform is no longer running
 * After we tell users to start `blast-radius`, but do not tell them to stop it, but rely on it not running later, use a challenge cleanup script to stop it
 * Make some checks a bit more robust
 * Fix some Bash quoting errors which could lead to silent failures
 * Slight clarification on some instructions