### PR TITLE
IL-728 terraform-intro-* fixes

### DIFF
--- a/instruqt-tracks/terraform-intro-aws/terraform-graph/solve-workstation
+++ b/instruqt-tracks/terraform-intro-aws/terraform-graph/solve-workstation
@@ -6,7 +6,6 @@ set -o history
 
 cd /root/hashicat-aws
 
-# This needs to be fixed so it runs cleanly.
 blast-radius --serve . > blastradius.log 2>&1 &
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/tf-graph/solve-workstation
+++ b/instruqt-tracks/terraform-intro-aws/tf-graph/solve-workstation
@@ -6,7 +6,6 @@ set -o history
 
 cd /root/hashicat-aws
 
-# This needs to be fixed so it runs cleanly.
 blast-radius --serve . > blastradius.log 2>&1 &
 
 exit 0

--- a/instruqt-tracks/terraform-intro-aws/track_scripts/setup-workstation
+++ b/instruqt-tracks/terraform-intro-aws/track_scripts/setup-workstation
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 # Track setup script
 
-set -e
+set -euvo pipefail
 
 # Wait for Instruqt to finish booting the VM
 # This is better than doing sleep
@@ -26,10 +26,19 @@ sudo apt-get update -y
 sudo apt-get install -y cowsay
 cp /usr/games/cowsay /usr/local/bin/cowsay
 
-# Install graphviz, pip, and BlastRadius
+# Needed for BlastRadius
 apt -y install graphviz
-apt -y install python3-pip
-/usr/bin/pip3 install BlastRadius
+
+# Install BlastRadius in a virtualenv to get around issues with
+# dependencies and system-installed versions of packages
+apt -y install virtualenv
+/usr/bin/virtualenv --python /usr/bin/python3 /root/venv
+source /root/venv/bin/activate
+pip3 install BlastRadius
+# Just add /root/venv/bin to PATH so we don't force participants
+# to have to activate the venv
+echo "PATH=/root/venv/bin:\${PATH}" >> /root/.bashrc
+echo "export PATH" >> /root/.bashrc
 
 # Clone the hashicat-aws repo
 git clone https://github.com/hashicorp/hashicat-aws

--- a/instruqt-tracks/terraform-intro-azure/tf-graph/solve-workstation
+++ b/instruqt-tracks/terraform-intro-azure/tf-graph/solve-workstation
@@ -6,7 +6,6 @@ set -o history
 
 cd /root/hashicat-azure
 
-# This needs to be fixed so it runs cleanly.
 blast-radius --serve . > blastradius.log 2>&1 &
 
 exit 0

--- a/instruqt-tracks/terraform-intro-azure/track_scripts/setup-workstation
+++ b/instruqt-tracks/terraform-intro-azure/track_scripts/setup-workstation
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 # Track setup script
 
-set -e
+set -euvo pipefail
 
 # Wait for Instruqt to finish booting the VM
 # This is better than doing sleep
@@ -26,10 +26,19 @@ sudo apt-get update -y
 sudo apt-get install -y cowsay
 cp /usr/games/cowsay /usr/local/bin/cowsay
 
-# Install graphviz, pip, and BlastRadius
+# Needed for BlastRadius
 apt -y install graphviz
-apt -y install python3-pip
-/usr/bin/pip3 install BlastRadius
+
+# Install BlastRadius in a virtualenv to get around issues with
+# dependencies and system-installed versions of packages
+apt -y install virtualenv
+/usr/bin/virtualenv --python /usr/bin/python3 /root/venv
+source /root/venv/bin/activate
+pip3 install BlastRadius
+# Just add /root/venv/bin to PATH so we don't force participants
+# to have to activate the venv
+echo "PATH=/root/venv/bin:\${PATH}" >> /root/.bashrc
+echo "export PATH" >> /root/.bashrc
 
 # Clone the hashicat-azure repo
 git clone https://github.com/hashicorp/hashicat-azure

--- a/instruqt-tracks/terraform-intro-gcp/setup-our-environment/check-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/setup-our-environment/check-workstation
@@ -7,9 +7,6 @@ if [ -f /tmp/skip-check ]; then
     exit 0
 fi
 
-# Sleep
-sleep 15
-
 # Make sure we have valid GCP credentials in our shell environment
 echo $GOOGLE_CREDENTIALS | jq -r .private_key > /tmp/privkey && chmod 600 /tmp/privkey && ssh-keygen -y -e -f /tmp/privkey || fail-message "Uh oh, you don't seem to have valid Google Cloud credentials. Please stop and restart the track."
 

--- a/instruqt-tracks/terraform-intro-gcp/terraform-graph/solve-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/terraform-graph/solve-workstation
@@ -6,7 +6,6 @@ set -o history
 
 cd /root/hashicat-gcp
 
-# This needs to be fixed so it runs cleanly.
 blast-radius --serve . > blastradius.log 2>&1 &
 
 exit 0

--- a/instruqt-tracks/terraform-intro-gcp/tf-graph/solve-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/tf-graph/solve-workstation
@@ -6,7 +6,6 @@ set -o history
 
 cd /root/hashicat-gcp
 
-# This needs to be fixed so it runs cleanly.
 blast-radius --serve . > blastradius.log 2>&1 &
 
 exit 0

--- a/instruqt-tracks/terraform-intro-gcp/track_scripts/setup-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/track_scripts/setup-workstation
@@ -42,9 +42,6 @@ cp ${GITDIR}/exercises/main.tf.start ${GITDIR}/main.tf
 cp ${GITDIR}/exercises/outputs.tf.start ${GITDIR}/outputs.tf
 mv ${GITDIR}/terraform.tfvars.example ${GITDIR}/terraform.tfvars
 
-echo "$INSTRUQT_GCP_PROJECT_GCP_PROJECT_PROJECT_ID"
-echo "$INSTRUQT_GCP_PROJECT_GCP_PROJECT_SERVICE_ACCOUNT_KEY" | base64 -d | jq 'tostring'
-
 # Store our project ID as a Terraform env var
 echo "TF_VAR_project=\"$INSTRUQT_GCP_PROJECT_GCP_PROJECT_PROJECT_ID\"" >> /root/.bashrc
 echo "export TF_VAR_project" >> /root/.bashrc

--- a/instruqt-tracks/terraform-intro-gcp/track_scripts/setup-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/track_scripts/setup-workstation
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 # Track setup script
 
-set -e
+set -euvo pipefail
 
 # Wait for Instruqt to finish booting the VM
 # This is better than doing sleep
@@ -42,10 +42,15 @@ cp ${GITDIR}/exercises/main.tf.start ${GITDIR}/main.tf
 cp ${GITDIR}/exercises/outputs.tf.start ${GITDIR}/outputs.tf
 mv ${GITDIR}/terraform.tfvars.example ${GITDIR}/terraform.tfvars
 
+echo "$INSTRUQT_GCP_PROJECT_GCP_PROJECT_PROJECT_ID"
+echo "$INSTRUQT_GCP_PROJECT_GCP_PROJECT_SERVICE_ACCOUNT_KEY" | base64 -d | jq 'tostring'
+
 # Store our project ID as a Terraform env var
-export TF_VAR_project=$INSTRUQT_GCP_PROJECT_GCP_PROJECT_PROJECT_ID
-grep $INSTRUQT_GCP_PROJECT_GCP_PROJECT_PROJECT_ID /root/.bashrc || echo "export TF_VAR_project=\"$INSTRUQT_GCP_PROJECT_GCP_PROJECT_PROJECT_ID\"" >> /root/.bashrc
-export GOOGLE_CREDENTIALS=$(echo $INSTRUQT_GCP_PROJECT_GCP_PROJECT_SERVICE_ACCOUNT_KEY | base64 -d | jq 'tostring')
-echo "export GOOGLE_CREDENTIALS=$GOOGLE_CREDENTIALS" >> /root/.bashrc
+echo "TF_VAR_project=\"$INSTRUQT_GCP_PROJECT_GCP_PROJECT_PROJECT_ID\"" >> /root/.bashrc
+echo "export TF_VAR_project" >> /root/.bashrc
+GOOGLE_CREDENTIALS=$(echo "$INSTRUQT_GCP_PROJECT_GCP_PROJECT_SERVICE_ACCOUNT_KEY" | base64 -d | jq 'tostring')
+# Do not quote '$GOOGLE_CREDENTIALS' because `jq 'tostring'` does that for us
+echo "GOOGLE_CREDENTIALS=$GOOGLE_CREDENTIALS" >> /root/.bashrc
+echo "export GOOGLE_CREDENTIALS" >> /root/.bashrc
 
 exit 0

--- a/instruqt-tracks/terraform-intro-gcp/track_scripts/setup-workstation
+++ b/instruqt-tracks/terraform-intro-gcp/track_scripts/setup-workstation
@@ -26,10 +26,19 @@ sudo apt-get update -y
 sudo apt-get install -y cowsay
 cp /usr/games/cowsay /usr/local/bin/cowsay
 
-# Install graphviz, pip, and BlastRadius
+# Needed for BlastRadius
 apt -y install graphviz
-apt -y install python3-pip
-/usr/bin/pip3 install BlastRadius
+
+# Install BlastRadius in a virtualenv to get around issues with
+# dependencies and system-installed versions of packages
+apt -y install virtualenv
+/usr/bin/virtualenv --python /usr/bin/python3 /root/venv
+source /root/venv/bin/activate
+pip3 install BlastRadius
+# Just add /root/venv/bin to PATH so we don't force participants
+# to have to activate the venv
+echo "PATH=/root/venv/bin:\${PATH}" >> /root/.bashrc
+echo "export PATH" >> /root/.bashrc
 
 # Clone the hashicat-gcp repo
 git clone https://github.com/hashicorp/hashicat-gcp


### PR DESCRIPTION
* `track_scripts/setup-workstation` ** Add some `set` options to be verbose, fail on empty variables
   and pipefail
** Make script pass `shellcheck`; in particular, when we
   `echo` variables, quote them so we don't get shenanigans if
   the variable has something weird in it; also set variables on
   one line and `export` them on the next, instead of doing both
   on the same line, since `export` can mask errors on the rest
   of the line when determining the variable value
** I have no idea why we're grepping for a value to see if it
   is in the root `.bashrc` when nothing thus far has set it
   (and why we didn't grep for the *variable* we are trying to
   set, and why we didn't do that for the subsequent variable
   we are trying to add....) so don't do that; just add it
* `setup-our-environment/check-workstation` - why are we sleeping for 15 seconds? Either the varaible is set or it isn't. Either `/bin/set-workdir` is there or it isn't. Sleeping isn't going to change either of those.