### PR TITLE
IL-734 Move non-checks from check script to cleanup script

### DIFF
--- a/instruqt-tracks/terraform-cloud-azure-v2/02-terraform-cloud-setup/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure-v2/02-terraform-cloud-setup/check-workstation
@@ -1,32 +1,9 @@
 #!/bin/bash -l
-set -e
+set -euxvo pipefail
 
 # Create /tmp/skip-check to disable this check
 if [ -f /tmp/skip-check ]; then
     rm /tmp/skip-check
-    exit 0
 fi
-
-export ORG=$(grep organization /root/terraform-cloud/terraform.tfvars | cut -d '"' -f2)
-export WORKSPACE=$(grep workspace /root/terraform-cloud/terraform.tfvars | cut -d '"' -f2)
-
-agent variable set TF_ORG $ORG
-agent variable set TF_WORKSPACE $WORKSPACE
-
-cp /root/hashicat-$CLOUD_ENV/remote_backend.tf.example /root/hashicat-$CLOUD_ENV/remote_backend.tf
-
-cd /root/hashicat-$CLOUD_ENV
-sed -i "s/YOUR_ORGANIZATION/$ORG/g" remote_backend.tf
-sed -i "s/YOUR_WORKSPACE/$WORKSPACE/g" remote_backend.tf
-
-cd /root/terraform-api
-sed -i "s/YOUR_ORGANIZATION/$ORG/g" terraform.tfvars.example
-mv terraform.tfvars.example terraform.tfvars
-
-# Store the ORG in /root/.bashrc
-grep $ORG /root/.bashrc || echo "export ORG=\"$ORG\"" >> /root/.bashrc
-
-# Store the WORKSPACE in /root/.bashrc
-grep $WORKSPACE /root/.bashrc || echo "export WORKSPACE=\"$WORKSPACE\"" >> /root/.bashrc
 
 exit 0

--- a/instruqt-tracks/terraform-cloud-azure-v2/02-terraform-cloud-setup/cleanup-workstation
+++ b/instruqt-tracks/terraform-cloud-azure-v2/02-terraform-cloud-setup/cleanup-workstation
@@ -1,0 +1,26 @@
+#!/bin/bash -l
+set -euxvo pipefail
+
+ORG=$(grep organization /root/terraform-cloud/terraform.tfvars | cut -d '"' -f2)
+WORKSPACE=$(grep workspace /root/terraform-cloud/terraform.tfvars | cut -d '"' -f2)
+
+agent variable set TF_ORG $ORG
+agent variable set TF_WORKSPACE $WORKSPACE
+
+cp /root/hashicat-$CLOUD_ENV/remote_backend.tf.example /root/hashicat-$CLOUD_ENV/remote_backend.tf
+
+cd /root/hashicat-$CLOUD_ENV
+sed -i "s/YOUR_ORGANIZATION/$ORG/g" remote_backend.tf
+sed -i "s/YOUR_WORKSPACE/$WORKSPACE/g" remote_backend.tf
+
+cd /root/terraform-api
+sed -i "s/YOUR_ORGANIZATION/$ORG/g" terraform.tfvars.example
+mv terraform.tfvars.example terraform.tfvars
+
+# Store the ORG in /root/.bashrc
+echo "export ORG=\"$ORG\"" >> /root/.bashrc
+
+# Store the WORKSPACE in /root/.bashrc
+echo "export WORKSPACE=\"$WORKSPACE\"" >> /root/.bashrc
+
+exit 0


### PR DESCRIPTION
In challenge 2 we use the check script to do a bunch of non-check work, setting some agent variables, copying around and changing some Terraform code, adding things to root's .bashrc, etc.

Check scripts do not always run. For example, a user who can skip tracks can skip this challenge and its check script will not run. Or a user who uses the `/tmp/skip-check` trick will cause the check script to exit before the necessary work is done.

Cleanup scripts, however, always run, and since we *require* those changes to happen, move them to the cleanup script.

In addition, we do things like

 `grep $ORG /root/.bashrc || echo "export ORG=\"$ORG\"" >> /root/.bashrc`

which is fragile because it is an unanchored grep, so if the user's $ORG or $WORKSPACE happens to match anything in the existing .bashrc we won't add the export line. In addition, we haven't actually added this line anywhere else in previous challenges, so just unconditionally set it in the cleanup script.