### PR TITLE
Fix module name in assignment and check script

### DIFF
--- a/instruqt-tracks/terraform-cloud-azure-v2/13-private-module-registry/assignment.md
+++ b/instruqt-tracks/terraform-cloud-azure-v2/13-private-module-registry/assignment.md
@@ -225,7 +225,7 @@ The main difference between these two methods is automation. In this workshop, w
 
 - Use the <t><img src="../assets/web.png"/>Code Editor</t> tab and expand the <t><img src="../assets/folder.png"/>hashicat-azure</t> folder.
 
-- Revise the `module "backupstorage"` code snippet in the file <t><img src="../assets/tf-icon.png"/>main.tf</t> and update with a reference to your Private Module registry. The code currently reads:
+- Revise the `module "azure-backup"` code snippet in the file <t><img src="../assets/tf-icon.png"/>main.tf</t> and update with a reference to your Private Module registry. The code currently reads:
 
 ```bash
 module "azure-backup" {

--- a/instruqt-tracks/terraform-cloud-azure-v2/13-private-module-registry/check-workstation
+++ b/instruqt-tracks/terraform-cloud-azure-v2/13-private-module-registry/check-workstation
@@ -15,7 +15,7 @@ TOKEN=$(grep token /root/.terraform.d/credentials.tfrc.json | cut -d '"' -f4)
 WORKSPACE_ID=$(curl -s --header "Authorization: Bearer $TOKEN"   --header "Content-Type: application/vnd.api+json"   https://app.terraform.io/api/v2/organizations/$ORG/workspaces/$WORKSPACE | jq -r .data.id)
 
 # Verify that Azure Blob bucket exists in the modules listed in the state file
-MODULE_EXIST=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" https://app.terraform.io/api/v2/workspaces/${WORKSPACE_ID}/current-state-version | jq '.data.attributes.modules | has("root.azure-backup")')
+MODULE_EXIST=$(curl -s --header "Authorization: Bearer $TOKEN" --header "Content-Type: application/vnd.api+json" https://app.terraform.io/api/v2/workspaces/${WORKSPACE_ID}/current-state-version | jq '.data.attributes.modules | has("root.backupstorage")')
 
 [[ $MODULE_EXIST == true ]] || fail-message "Uh oh, we couldn't find the Azure Blob Storage module in your remote state file. Make sure you have added the Azure Blob Storage module to your main.tf file and pushed it to your remote repository."
 


### PR DESCRIPTION
The assignment text had an unclear reference to the module resource name, and the check script used the incorrect module name for the state check.