### PR TITLE
VCDL-130 changing instructions to use GITHUB_OWNER not GITHUB_ORGANIZATION

### DIFF
--- a/instruqt-tracks/terraform-cloud-azure-v2/08-versioned-infrastructure/assignment.md
+++ b/instruqt-tracks/terraform-cloud-azure-v2/08-versioned-infrastructure/assignment.md
@@ -188,7 +188,7 @@ git init
 git add .
 git commit -m "first commit"
 git branch -M main
-git remote add origin https://github.com/$GITHUB_ORGANIZATION/$GITHUB_REPO.git
+git remote add origin https://github.com/$GITHUB_OWNER/$GITHUB_REPO.git
 git push -u origin main
 
 
@@ -198,7 +198,7 @@ git push -u origin main
 
 ```bash
 echo "" && \
-echo "https://github.com/${GITHUB_ORGANIZATION}/${GITHUB_REPO}" && \
+echo "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}" && \
 echo ""
 
 
@@ -249,7 +249,7 @@ Please see the example image below.
 
 ```bash
 echo "" && \
-echo "https://github.com/${GITHUB_ORGANIZATION}/${GITHUB_REPO}/settings/hooks" && \
+echo "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/settings/hooks" && \
 echo ""
 
 

--- a/instruqt-tracks/terraform-cloud-gcp-v2/08-versioned-infrastructure/assignment.md
+++ b/instruqt-tracks/terraform-cloud-gcp-v2/08-versioned-infrastructure/assignment.md
@@ -189,7 +189,7 @@ git init
 git add .
 git commit -m "first commit"
 git branch -M main
-git remote add origin https://github.com/$GITHUB_ORGANIZATION/$GITHUB_REPO.git
+git remote add origin https://github.com/$GITHUB_OWNER/$GITHUB_REPO.git
 git push -u origin main
 
 
@@ -199,7 +199,7 @@ git push -u origin main
 
 ```bash
 echo "" && \
-echo "https://github.com/${GITHUB_ORGANIZATION}/${GITHUB_REPO}" && \
+echo "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}" && \
 echo ""
 
 
@@ -250,7 +250,7 @@ Please see the example image below.
 
 ```bash
 echo "" && \
-echo "https://github.com/${GITHUB_ORGANIZATION}/${GITHUB_REPO}/settings/hooks" && \
+echo "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}/settings/hooks" && \
 echo ""
 
 


### PR DESCRIPTION
Forgot to change the assignment.md files for the Azure and GCP tracks to not use the deprecated GITHUB_ORGANIZATION parameter 