### PR TITLE
VCDL-666 removing instructions to create TFC org before workshops

### DIFF
--- a/instructor-guides/all_terraform_cloud_INSTRUCTOR_GUIDE.md
+++ b/instructor-guides/all_terraform_cloud_INSTRUCTOR_GUIDE.md
@@ -18,7 +18,7 @@ Prerequisites for these workshops are as follows:
 * A trial-enabled organization in Terraform Cloud
 * A Github.com account
 
-We strongly recommend having your participants sign up for Terraform Cloud *before* the training.  Users who create new organizations and have not already used a free 30 day trial can enable a free trial on their new organizations themselves.
+Participants may sign up for a Terraform Cloud account *before* the training, however they will have the option of creating an account during the workshop. Users will be instructed to create a new 14 day *trial* organization in the Instruqt track. They should NOT be using an existing organization. 
 
 **Work with your local SME or Terraform Cloud admin to get your organizations upgraded to trials.**
 


### PR DESCRIPTION
Feedback from a workshop run on 3/26/24: there were instructions in the instructor guide that suggested having the users create a TFC account and org before the workshop. We do not want users creating an org before the workshop anymore bc they have to use the trial org link in the track!!